### PR TITLE
[directinput] Defer joystick acquisition to initialization

### DIFF
--- a/src/api/directinput/JoystickDirectInput.cpp
+++ b/src/api/directinput/JoystickDirectInput.cpp
@@ -69,6 +69,16 @@ bool CJoystickDirectInput::Initialize(void)
 {
   HRESULT hr;
 
+  // This will be done automatically when we're in the foreground but
+  // let's do it here to check that we can acquire it and that no other
+  // app has it in exclusive mode
+  hr = m_joystickDevice->Acquire();
+  if (FAILED(hr))
+  {
+    esyslog("%s: Failed to acquire device on: %s", __FUNCTION__, Name().c_str());
+    return false;
+  }
+
   // Get capabilities
   DIDEVCAPS diDevCaps;
   diDevCaps.dwSize = sizeof(DIDEVCAPS);

--- a/src/api/directinput/JoystickInterfaceDirectInput.cpp
+++ b/src/api/directinput/JoystickInterfaceDirectInput.cpp
@@ -142,16 +142,6 @@ BOOL CALLBACK CJoystickInterfaceDirectInput::EnumJoysticksCallback(const DIDEVIC
     return DIENUM_CONTINUE;
   }
 
-  // This will be done automatically when we're in the foreground but
-  // let's do it here to check that we can acquire it and that no other
-  // app has it in exclusive mode
-  hr = pJoystick->Acquire();
-  if (FAILED(hr))
-  {
-    esyslog("%s: Failed to acquire device on: %s", __FUNCTION__, pdidInstance->tszProductName);
-    return DIENUM_CONTINUE;
-  }
-
   const std::string strName = pdidInstance->tszProductName ? pdidInstance->tszProductName : "";
 
   context->AddScanResult(JoystickPtr(new CJoystickDirectInput(pdidInstance->guidInstance, pJoystick, strName)));


### PR DESCRIPTION
This fixes a problem where joystick are discovered and then lost every five seconds.

Reported here: http://forum.kodi.tv/showthread.php?tid=295548&pid=2449281#pid2449281