### PR TITLE
Fix loss of control if A becomes unmapped

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(JOYSTICK_SOURCES src/addon.cpp
                      src/api/PeripheralScanner.cpp
                      src/buttonmapper/ButtonMapper.cpp
                      src/buttonmapper/ButtonMapTranslator.cpp
+                     src/buttonmapper/ButtonMapUtils.cpp
                      src/buttonmapper/ControllerTransformer.cpp
                      src/buttonmapper/DriverGeometry.cpp
                      src/buttonmapper/JoystickFamily.cpp

--- a/src/buttonmapper/ButtonMapUtils.cpp
+++ b/src/buttonmapper/ButtonMapUtils.cpp
@@ -1,0 +1,56 @@
+/*
+ *      Copyright (C) 2016 Garrett Brown
+ *      Copyright (C) 2016 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ButtonMapUtils.h"
+
+#include "kodi_peripheral_utils.hpp"
+
+using namespace JOYSTICK;
+
+bool ButtonMapUtils::PrimitivesEqual(const ADDON::JoystickFeature& lhs, const ADDON::JoystickFeature& rhs)
+{
+  if (lhs.Type() == rhs.Type())
+  {
+    switch (lhs.Type())
+    {
+    case JOYSTICK_FEATURE_TYPE_SCALAR:
+    case JOYSTICK_FEATURE_TYPE_MOTOR:
+    {
+      return lhs.Primitive(JOYSTICK_SCALAR_PRIMITIVE) == rhs.Primitive(JOYSTICK_SCALAR_PRIMITIVE);
+    }
+    case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
+    {
+      return lhs.Primitive(JOYSTICK_ANALOG_STICK_UP)    == rhs.Primitive(JOYSTICK_ANALOG_STICK_UP) &&
+             lhs.Primitive(JOYSTICK_ANALOG_STICK_DOWN)  == rhs.Primitive(JOYSTICK_ANALOG_STICK_DOWN) &&
+             lhs.Primitive(JOYSTICK_ANALOG_STICK_RIGHT) == rhs.Primitive(JOYSTICK_ANALOG_STICK_RIGHT) &&
+             lhs.Primitive(JOYSTICK_ANALOG_STICK_LEFT)  == rhs.Primitive(JOYSTICK_ANALOG_STICK_LEFT);
+    }
+    case JOYSTICK_FEATURE_TYPE_ACCELEROMETER:
+    {
+      return lhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_X) == rhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_X) &&
+             lhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y) == rhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y) &&
+             lhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z) == rhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z);
+    }
+    default:
+      break;
+    }
+  }
+  return false;
+}

--- a/src/buttonmapper/ButtonMapUtils.h
+++ b/src/buttonmapper/ButtonMapUtils.h
@@ -1,0 +1,37 @@
+/*
+ *      Copyright (C) 2016 Garrett Brown
+ *      Copyright (C) 2016 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+namespace ADDON
+{
+  class JoystickFeature;
+}
+
+namespace JOYSTICK
+{
+  class ButtonMapUtils
+  {
+  public:
+    /*!
+     * \brief Check if two features having matching primitives
+     */
+    static bool PrimitivesEqual(const ADDON::JoystickFeature& lhs, const ADDON::JoystickFeature& rhs);
+  };
+}

--- a/src/storage/ButtonMap.h
+++ b/src/storage/ButtonMap.h
@@ -58,7 +58,9 @@ namespace JOYSTICK
     virtual bool Load(void) = 0;
     virtual bool Save(void) const = 0;
 
-    static void Sanitize(const std::string& controllerId, FeatureVector& features);
+    static void MergeFeature(const ADDON::JoystickFeature& feature, FeatureVector& features, const std::string& controllerId);
+
+    static void Sanitize(FeatureVector& features, const std::string& controllerId);
 
     static std::set<unsigned int> GetAxes(const FeatureVector& features);
 

--- a/src/storage/ButtonMap.h
+++ b/src/storage/ButtonMap.h
@@ -22,6 +22,8 @@
 #include "StorageTypes.h"
 #include "buttonmapper/ButtonMapTypes.h"
 
+#include <set>
+#include <stdint.h>
 #include <string>
 
 namespace JOYSTICK
@@ -57,6 +59,8 @@ namespace JOYSTICK
     virtual bool Save(void) const = 0;
 
     static void Sanitize(const std::string& controllerId, FeatureVector& features);
+
+    static std::set<unsigned int> GetAxes(const FeatureVector& features);
 
     const std::string m_strResourcePath;
     DevicePtr         m_device;


### PR DESCRIPTION
When a feature is updated, it might conflict with an existing feature. Instead of erasing the existing feature, an attempt is made to update its primitives to the old feature being overwritten.

For example, if the button map is:

A -> 0
B -> 1

And the user maps "B -> 0", then the new button map will look like:

A -> 1
B -> 0

Here, instead of erasing the A (button 0) when it conflicts with the new B (also button 0), the A is updated to point to B's old button (1).

Part of https://github.com/xbmc/xbmc/pull/10630