### PR TITLE
Added buttonmap for PS4 controller

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_14b_18a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_14b_18a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Wireless Controller" provider="linux" buttoncount="14" axiscount="18">
+        <configuration />
+        <controller id="game.controller.default">
+            <feature name="a" button="1" />
+            <feature name="b" button="2" />
+            <feature name="back" button="8" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="12" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="10" />
+            <feature name="lefttrigger" button="6" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-5" />
+                <down axis="+5" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+            <feature name="rightthumb" button="11" />
+            <feature name="righttrigger" button="7" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="0" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
This is the buttonmap for the PS4 controller when connected through Bluetooth. It is recognized as Wireless Controller. It maps all the buttons, except the trackpad in the middle which doesn't really match with anything on the "standard" controller shown on-screen in the controller configuration dialog anyway. However, it only has the mapping for the default game controller.

I can also provide the buttonmap for this PS4 controller from when it's connected through a USB cable. Then it's recognized as "Sony Computer Entertainment Wireless Controller". But I figured I'd do it one at a time. Although the only difference is the name attribute in the <device> tag and the filename.