### PR TITLE
Added buttonmap for PS4 controller (connected through USB)

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Computer_Entertainment_Wireless_Controller_14b_18a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Computer_Entertainment_Wireless_Controller_14b_18a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Sony Computer Entertainment Wireless Controller" provider="linux" buttoncount="14" axiscount="18">
+        <configuration />
+        <controller id="game.controller.default">
+            <feature name="a" button="1" />
+            <feature name="b" button="2" />
+            <feature name="back" button="8" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="12" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="10" />
+            <feature name="lefttrigger" button="6" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-5" />
+                <down axis="+5" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+            <feature name="rightthumb" button="11" />
+            <feature name="righttrigger" button="7" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="0" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
This is the buttonmap for the PS4 controller when it's connected through USB. The mapping is entirely the same as when connected through Bluetooth, only the controller name is different. As with the Bluetooth mapping, this is only for the default game controller in Kodi and doesn't map the touchpad. 