### PR TITLE
Added buttonmap for PS4 V2 controller

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_14b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_14b_8a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Wireless Controller" provider="linux" buttoncount="14" axiscount="8">
+        <configuration />
+        <controller id="game.controller.default">
+            <feature name="a" button="1" />
+            <feature name="b" button="2" />
+            <feature name="back" button="8" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="12" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="10" />
+            <feature name="lefttrigger" button="6" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-5" />
+                <down axis="+5" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+            <feature name="rightthumb" button="11" />
+            <feature name="righttrigger" button="7" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="0" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
I recently got the V2 version of the PS4 controller, released together with the PS4 Pro. It seems this one is recognized a little differently than the original version, though it's also recognized with the name "Wireless Controller". It seems to be recognized with 8 axes instead of 18 (maybe this makes it better compatible with udev?). I've created a buttonmap for it, which is available through this PR. It seems like both controllers work pretty well, even when connected at the same time. The actual contents of the buttonmap is exactly the same as for V1 of the PS4 controller, except for the axes count. 