### PR TITLE
Fix Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,6 @@ before_script:
   - cd $TRAVIS_BUILD_DIR/..
   - git clone --depth=1 https://github.com/xbmc/xbmc.git
   - cd peripheral.joystick && mkdir build && cd build
-  - cmake -DADDONS_TO_BUILD=peripheral.joystick -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/project/cmake/addons
+  - cmake -DADDONS_TO_BUILD=peripheral.joystick -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
 
 script: make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,5 +32,5 @@ build_script:
   - cd %app_id%
   - mkdir build
   - cd build
-  - cmake -G "NMake Makefiles" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/project/cmake/addons
+  - cmake -G "NMake Makefiles" -DADDONS_TO_BUILD=%app_id% -DCMAKE_BUILD_TYPE=%CONFIG% -DADDON_SRC_PREFIX=../.. -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
   - cmake --build "%cur_dir%\build" --target %app_id%


### PR DESCRIPTION
In https://github.com/xbmc/xbmc/pull/10446 the cmake folder was moved from `project` directory to the root directory.