### PR TITLE
Update NES30 buttonmap for latest firmware

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_GamePad_16b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_GamePad_16b_8a.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="8Bitdo NES30 GamePad" provider="linux" buttoncount="16" axiscount="8">
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="10" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" button="6" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" button="7" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="3" />
+            <feature name="y" button="4" />
+        </controller>
+        <controller id="game.controller.gba">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" button="6" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" button="7" />
+            <feature name="select" button="10" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-1" />
+        </controller>
+        <controller id="game.controller.genesis">
+            <feature name="a" button="4" />
+            <feature name="b" button="1" />
+            <feature name="c" button="0" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="mode" button="10" />
+            <feature name="right" axis="+0" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="6" />
+            <feature name="y" button="3" />
+            <feature name="z" button="7" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="right" axis="+0" />
+            <feature name="select" button="10" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-1" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" button="6" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" button="7" />
+            <feature name="select" button="10" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="3" />
+            <feature name="y" button="4" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Adds support for the NES30 in normal "Joystick" mode, which is different from the currently supported NES30 in "PC Joystick" mode. [See the v2.52 firmware notes](http://www.nes30.com/firmware.html).

---

#### Old PR description:

It appears in the latest firmware of the NES30 the device reports **16** buttons, not **22**. This allows XBMC to correctly identify it.

This also corrects the name of the device as it does not include `Joystick` in bluetooth mode.

I've never seen my NES30 report itself with the suffix `Joystick` in bluetooth mode. I am on Arch Linux however, maybe it reports differently on Windows and OSX. It's quite possible this device should have an alias added without the Joystick suffix. Pinging @N3MIS15 for information about his setup.