### PR TITLE
[xinput] Remove use of private APIs on Windows 8/10

### DIFF
--- a/src/api/xinput/JoystickInterfaceXInput.cpp
+++ b/src/api/xinput/JoystickInterfaceXInput.cpp
@@ -47,12 +47,22 @@ void CJoystickInterfaceXInput::Deinitialize(void)
 
 bool CJoystickInterfaceXInput::ScanForJoysticks(JoystickVector& joysticks)
 {
-  XINPUT_STATE_EX controllerState; // No need to memset, only checking for controller existence
+  // No need to memset, only checking for controller existence
+  XINPUT_STATE controllerState;
+  XINPUT_STATE_EX controllerStateWithGuide;
 
   for (unsigned int i = 0; i < MAX_JOYSTICKS; i++)
   {
-    if (!CXInputDLL::Get().GetState(i, controllerState))
-      continue;
+    if (CXInputDLL::Get().Version() == "1.3")
+    {
+      if (!CXInputDLL::Get().GetStateWithGuide(i, controllerStateWithGuide))
+        continue;
+    }
+    else
+    {
+      if (!CXInputDLL::Get().GetState(i, controllerState))
+        continue;
+    }
 
     joysticks.push_back(JoystickPtr(new CJoystickXInput(i)));
   }

--- a/src/api/xinput/JoystickXInput.cpp
+++ b/src/api/xinput/JoystickXInput.cpp
@@ -67,40 +67,75 @@ bool CJoystickXInput::Equals(const CJoystick* rhs) const
 
 void CJoystickXInput::PowerOff()
 {
-  CXInputDLL::Get().PowerOff(m_controllerID);
+  if (CXInputDLL::Get().Version() == "1.3")
+    CXInputDLL::Get().PowerOff(m_controllerID);
 }
 
 bool CJoystickXInput::ScanEvents(void)
 {
-  XINPUT_STATE_EX controllerState;
+  if (CXInputDLL::Get().Version() == "1.3")
+  {
+    XINPUT_STATE_EX controllerState;
 
-  if (!CXInputDLL::Get().GetState(m_controllerID, controllerState))
-    return false;
+    if (!CXInputDLL::Get().GetStateWithGuide(m_controllerID, controllerState))
+      return false;
 
-  m_dwPacketNumber = controllerState.dwPacketNumber;
+    m_dwPacketNumber = controllerState.dwPacketNumber;
 
-  SetButtonValue(0,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_A)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(1,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_B)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(2,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_X)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(3,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_Y)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(4,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER)  ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(5,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER) ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(6,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_BACK)           ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(7,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_START)          ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(8,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_LEFT_THUMB)     ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(9,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_RIGHT_THUMB)    ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(10, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_UP)        ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(11, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_RIGHT)     ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(12, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_DOWN)      ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(13, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_LEFT)      ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
-  SetButtonValue(14, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_GUIDE)          ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(0,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_A)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(1,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_B)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(2,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_X)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(3,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_Y)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(4,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER)  ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(5,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER) ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(6,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_BACK)           ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(7,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_START)          ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(8,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_LEFT_THUMB)     ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(9,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_RIGHT_THUMB)    ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(10, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_UP)        ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(11, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_RIGHT)     ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(12, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_DOWN)      ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(13, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_LEFT)      ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(14, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_GUIDE)          ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
 
-  SetAxisValue(0, (long)controllerState.Gamepad.sThumbLX, MAX_AXIS);
-  SetAxisValue(1, (long)controllerState.Gamepad.sThumbLY, MAX_AXIS);
-  SetAxisValue(2, (long)controllerState.Gamepad.sThumbRX, MAX_AXIS);
-  SetAxisValue(3, (long)controllerState.Gamepad.sThumbRY, MAX_AXIS);
-  SetAxisValue(4, (long)controllerState.Gamepad.bLeftTrigger, MAX_TRIGGER);
-  SetAxisValue(5, (long)controllerState.Gamepad.bRightTrigger, MAX_TRIGGER);
+    SetAxisValue(0, (long)controllerState.Gamepad.sThumbLX, MAX_AXIS);
+    SetAxisValue(1, (long)controllerState.Gamepad.sThumbLY, MAX_AXIS);
+    SetAxisValue(2, (long)controllerState.Gamepad.sThumbRX, MAX_AXIS);
+    SetAxisValue(3, (long)controllerState.Gamepad.sThumbRY, MAX_AXIS);
+    SetAxisValue(4, (long)controllerState.Gamepad.bLeftTrigger, MAX_TRIGGER);
+    SetAxisValue(5, (long)controllerState.Gamepad.bRightTrigger, MAX_TRIGGER);
+  }
+  else
+  {
+    XINPUT_STATE controllerState;
+
+    if (!CXInputDLL::Get().GetState(m_controllerID, controllerState))
+      return false;
+
+    m_dwPacketNumber = controllerState.dwPacketNumber;
+
+    SetButtonValue(0,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_A)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(1,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_B)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(2,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_X)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(3,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_Y)              ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(4,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER)  ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(5,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER) ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(6,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_BACK)           ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(7,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_START)          ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(8,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_LEFT_THUMB)     ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(9,  (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_RIGHT_THUMB)    ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(10, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_UP)        ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(11, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_RIGHT)     ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(12, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_DOWN)      ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+    SetButtonValue(13, (controllerState.Gamepad.wButtons & XINPUT_GAMEPAD_DPAD_LEFT)      ? JOYSTICK_STATE_BUTTON_PRESSED : JOYSTICK_STATE_BUTTON_UNPRESSED);
+
+    SetAxisValue(0, (long)controllerState.Gamepad.sThumbLX, MAX_AXIS);
+    SetAxisValue(1, (long)controllerState.Gamepad.sThumbLY, MAX_AXIS);
+    SetAxisValue(2, (long)controllerState.Gamepad.sThumbRX, MAX_AXIS);
+    SetAxisValue(3, (long)controllerState.Gamepad.sThumbRY, MAX_AXIS);
+    SetAxisValue(4, (long)controllerState.Gamepad.bLeftTrigger, MAX_TRIGGER);
+    SetAxisValue(5, (long)controllerState.Gamepad.bRightTrigger, MAX_TRIGGER);
+  }
 
   return true;
 }

--- a/src/api/xinput/XInputDLL.h
+++ b/src/api/xinput/XInputDLL.h
@@ -63,7 +63,8 @@ namespace JOYSTICK
     // Available after library is loaded successfully
     const std::string& Version(void) const { return m_strVersion; }
 
-    bool GetState(unsigned int controllerId, XINPUT_STATE_EX& state);
+    bool GetState(unsigned int controllerId, XINPUT_STATE& state);
+    bool GetStateWithGuide(unsigned int controllerId, XINPUT_STATE_EX& state);
     bool SetState(unsigned int controllerId, XINPUT_VIBRATION& vibration);
     bool GetCapabilities(unsigned int controllerId, XINPUT_CAPABILITIES& caps);
 
@@ -80,7 +81,8 @@ namespace JOYSTICK
     // Forward decl's for XInput API's we load dynamically and use if available
     // [in] Index of the gamer associated with the device
     // [out] Receives the current state
-    typedef DWORD (WINAPI* FnXInputGetState)(DWORD dwUserIndex, XINPUT_STATE_EX* pState);
+    typedef DWORD (WINAPI* FnXInputGetState)(DWORD dwUserIndex, XINPUT_STATE* pState);
+    typedef DWORD (WINAPI* FnXInputGetStateEx)(DWORD dwUserIndex, XINPUT_STATE_EX* pState);
 
     // [in] Index of the gamer associated with the device
     // [in, out] The vibration information to send to the controller
@@ -101,6 +103,7 @@ namespace JOYSTICK
     HMODULE m_dll;
     std::string m_strVersion;
     FnXInputGetState m_getState;
+    FnXInputGetStateEx m_getStateEx;
     FnXInputSetState m_setState;
     FnXInputGetCapabilities m_getCaps;
     FnXInputGetBatteryInformation m_getBatteryInfo;


### PR DESCRIPTION
The crash on Windows 10:

```
INVALID_POINTER_READ_DETOURS_c0000005_XInputUap.dll!XInputCore::XInputManager::_XInputManager
```

This might be caused by the private API used to access the Guide button and Power-off feature. This PR disables these on Windows 10.

I can't compile on Windows ATM so this PR is untested.