### PR TITLE
Don't trim trailing space from joystick name

### DIFF
--- a/src/api/Joystick.cpp
+++ b/src/api/Joystick.cpp
@@ -54,12 +54,10 @@ bool CJoystick::Equals(const CJoystick* rhs) const
 
 void CJoystick::SetName(const std::string& strName)
 {
-  std::string strSanitizedFilename(strName);
+  std::string strSanitizedFilename = StringUtils::MakeSafeString(strName);
 
   // Remove Bluetooth MAC address as seen in Sony Playstation controllers
   StringUtils::RemoveMACAddress(strSanitizedFilename);
-
-  StringUtils::Trim(strSanitizedFilename);
 
   ADDON::Joystick::SetName(strSanitizedFilename);
 }

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -68,6 +68,20 @@ std::string StringUtils::MakeSafeUrl(const std::string& str)
   return safeUrl;
 }
 
+std::string StringUtils::MakeSafeString(std::string str)
+{
+  std::transform(str.begin(), str.end(), str.begin(),
+    [](char c)
+    {
+      if (c < 0x20)
+        return ' ';
+
+      return c;
+    });
+
+  return str;
+}
+
 std::string& StringUtils::RemoveMACAddress(std::string& str)
 {
   pcrecpp::RE re("[\\(\\[]?([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})[\\)\\]]?");

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -42,6 +42,16 @@ namespace JOYSTICK
     static std::string MakeSafeUrl(const std::string& str);
 
     /*!
+     * \brief Transform characters to create a safe, printable string
+     * \param str The string to transform
+     * \return The transformed string, with unsafe characters replaced by " "
+     *
+     * Unsafe characters are defined as the non-printable ASCII characters
+     * (character code 0-31).
+     */
+    static std::string MakeSafeString(std::string str);
+
+    /*!
      * \brief Removes a MAC address from a given string
      * \param str The string containing a MAC address
      * \return The string without the MAC address (for chaining)


### PR DESCRIPTION
Joystick drivers report all sorts of interesting names. Currently, if the name has trailing spaces, they are stripped before serializing.

Instead, we should serialize the full string, including trailing spaces, because

* Trimming spaces loses information
* RetroArch joystick configs include spaces