### PR TITLE
[debian] add libudev-dev to build-deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-peripheral-joystick
 Priority: extra
 Maintainer: wsnipex <wsnipex@a1.net>
 Build-Depends: debhelper (>= 9.0.0), cmake, libkodiplatform-dev (>= 17.0.0),
-               kodi-addon-dev, kodi-peripheral-dev, pkg-config, libp8-platform-dev, libpcre3-dev
+               kodi-addon-dev, kodi-peripheral-dev, pkg-config, libp8-platform-dev, libpcre3-dev, libudev-dev
 Standards-Version: 3.9.6
 Section: libs
 


### PR DESCRIPTION
needed to fix ubuntu packaging