### PR TITLE
Fix linking error on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ if("${CORE_SYSTEM_NAME}" STREQUAL "darwin" OR "${CORE_SYSTEM_NAME}" STREQUAL "os
                                src/api/cocoa/JoystickInterfaceCocoa.cpp)
 
   list(APPEND DEPLIBS ${COCOA_LIBRARY})
+  list(APPEND DEPLIBS "-framework IOKit")
 endif()
 
 # --- Linux Joystick API -------------------------------------------------------


### PR DESCRIPTION
Error was:
```
[100%] Linking CXX shared library peripheral.joystick.dylib
Undefined symbols for architecture x86_64:
  "_IOHIDDeviceCopyMatchingElements", referenced from:
      JOYSTICK::CJoystickCocoa::Initialize() in JoystickCocoa.cpp.o
  "_IOHIDDeviceGetProperty", referenced from:
      JOYSTICK::CJoystickCocoa::Initialize() in JoystickCocoa.cpp.o
  "_IOHIDElementGetDevice", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::InputValueChanged(__IOHIDValue*) in JoystickInterfaceCocoa.cpp.o
  "_IOHIDElementGetLogicalMax", referenced from:
      JOYSTICK::CJoystickCocoa::Initialize() in JoystickCocoa.cpp.o
  "_IOHIDElementGetLogicalMin", referenced from:
      JOYSTICK::CJoystickCocoa::Initialize() in JoystickCocoa.cpp.o
  "_IOHIDElementGetUsage", referenced from:
      JOYSTICK::CJoystickCocoa::Initialize() in JoystickCocoa.cpp.o
  "_IOHIDElementGetUsagePage", referenced from:
      JOYSTICK::CJoystickCocoa::Initialize() in JoystickCocoa.cpp.o
  "_IOHIDManagerClose", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::Deinitialize() in JoystickInterfaceCocoa.cpp.o
      JOYSTICK::CJoystickInterfaceCocoa::~CJoystickInterfaceCocoa() in JoystickInterfaceCocoa.cpp.o
  "_IOHIDManagerCreate", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::Initialize() in JoystickInterfaceCocoa.cpp.o
  "_IOHIDManagerOpen", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::Initialize() in JoystickInterfaceCocoa.cpp.o
  "_IOHIDManagerRegisterDeviceMatchingCallback", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::Initialize() in JoystickInterfaceCocoa.cpp.o
  "_IOHIDManagerRegisterDeviceRemovalCallback", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::Initialize() in JoystickInterfaceCocoa.cpp.o
  "_IOHIDManagerRegisterInputValueCallback", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::Initialize() in JoystickInterfaceCocoa.cpp.o
  "_IOHIDManagerScheduleWithRunLoop", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::Initialize() in JoystickInterfaceCocoa.cpp.o
  "_IOHIDManagerSetDeviceMatchingMultiple", referenced from:
      JOYSTICK::CJoystickInterfaceCocoa::Initialize() in JoystickInterfaceCocoa.cpp.o
  "_IOHIDValueGetElement", referenced from:
      JOYSTICK::CJoystickCocoa::InputValueChanged(__IOHIDValue*) in JoystickCocoa.cpp.o
      JOYSTICK::CJoystickInterfaceCocoa::InputValueChanged(__IOHIDValue*) in JoystickInterfaceCocoa.cpp.o
  "_IOHIDValueGetIntegerValue", referenced from:
      JOYSTICK::CJoystickCocoa::InputValueChanged(__IOHIDValue*) in JoystickCocoa.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[7]: *** [peripheral.joystick.1.3.2.dylib] Error 1
make[6]: *** [CMakeFiles/peripheral.joystick.dir/all] Error 2
make[5]: *** [all] Error 2
make[4]: *** [peripheral.joystick-prefix/src/peripheral.joystick-stamp/peripheral.joystick-build] Error 2
make[3]: *** [CMakeFiles/peripheral.joystick.dir/all] Error 2
make[2]: *** [CMakeFiles/peripheral.joystick.dir/rule] Error 2
make[1]: *** [peripheral.joystick] Error 2
```