### PR TITLE
Fix iMON conflicts by allowing settings to enable/disable interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ peripheral.joystick/project/VS2010Express/Release
 peripheral.joystick/*.so
 peripheral.joystick/*.dll
 peripheral.joystick/addon.xml
+peripheral.joystick/resources/settings.xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,3 +154,28 @@ endif()
 
 build_addon(peripheral.joystick JOYSTICK DEPLIBS)
 
+# ------------------------------------------------------------------------------
+
+set(LINUX_SELECT_LINE      "<setting label=\"30001\" type=\"select\" id=\"driver_linux\" lvalues=\"30005|30007|30002\"/>")
+set(SDL_SELECT_LINE        "<setting label=\"30001\" type=\"select\" id=\"driver_sdl\" lvalues=\"30008|30005|30007|30002\"/>")
+set(OSX_SELECT_LINE        "<setting label=\"30001\" type=\"select\" id=\"driver_linux\" lvalues=\"30006|30002\"/>")
+set(XINPUT_CHECK_LINE      "<setting label=\"30003\" type=\"bool\" id=\"driver_xinput\" default=\"true\"/>")
+set(DIRECTINPUT_CHECK_LINE "<setting label=\"30004\" type=\"bool\" id=\"driver_directinput\" default=\"true\"/>")
+
+# Write settings.xml.include
+if(CORE_SYSTEM_NAME STREQUAL windows)
+  set(XINPUT_CHECK "${XINPUT_CHECK_LINE}")
+  set(DIRECTINPUT_CHECK "${DIRECTINPUT_CHECK_LINE}")
+elseif(CORE_SYSTEM_NAME STREQUAL osx)
+  set(OSX_SELECT "${OSX_SELECT_LINE}")
+else()
+  if(SDL2_FOUND)
+    set(SDL_SELECT "${SDL_SELECT_LINE}")
+  else()
+    set(LINUX_SELECT "${LINUX_SELECT_LINE}")
+  endif()
+endif()
+
+file(READ ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}/resources/settings.xml.include settings_file)
+string(CONFIGURE "${settings_file}" settings_file_conf @ONLY)
+file(GENERATE OUTPUT ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}/resources/settings.xml CONTENT "${settings_file_conf}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(JOYSTICK_SOURCES src/addon.cpp
                      src/api/JoystickInterfaceCallback.cpp
                      src/api/JoystickManager.cpp
                      src/api/JoystickTranslator.cpp
+                     src/api/JoystickUtils.cpp
                      src/api/PeripheralScanner.cpp
                      src/buttonmapper/ButtonMapper.cpp
                      src/buttonmapper/ButtonMapTranslator.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ include_directories(${INCLUDES}
                     ${PCRE_INCLUDE_DIRS})
 
 set(JOYSTICK_SOURCES src/addon.cpp
+                     src/api/IJoystickInterface.cpp
                      src/api/Joystick.cpp
                      src/api/JoystickInterfaceCallback.cpp
                      src/api/JoystickManager.cpp

--- a/peripheral.joystick/resources/language/English/strings.po
+++ b/peripheral.joystick/resources/language/English/strings.po
@@ -1,0 +1,61 @@
+# peripheral.joystick language file
+# Addon Name: peripheral.joystick
+# Addon id: peripheral.joystick
+# Addon Provider: Team Kodi
+msgid ""
+msgstr ""
+"Project-Id-Version: peripheral.joystick\n"
+"Report-Msgid-Bugs-To: alanwww1@xbmc.org\n"
+"POT-Creation-Date: 2016-12-06 21:53i\n"
+"PO-Revision-Date: 2016-12-06 21:53i\n"
+"Last-Translator: Kodi Translation Team\n"
+"Language-Team: English (http://www.transifex.com/projects/p/xbmc-addons/language/en/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgctxt "#30000"
+msgid "Driver settings"
+msgstr ""
+
+msgctxt "#30001"
+msgid "Joystick driver"
+msgstr ""
+
+msgctxt "#30002"
+msgid "None"
+msgstr ""
+
+msgctxt "#30003"
+msgid "Enable XInput"
+msgstr ""
+
+msgctxt "#30004"
+msgid "Enable DirectInput"
+msgstr ""
+
+#. Do not translate
+msgctxt "#30005"
+msgid "Linux"
+msgstr ""
+
+#. Do not translate
+msgctxt "#30006"
+msgid "Cocoa"
+msgstr ""
+
+#. Do not translate
+msgctxt "#30007"
+msgid "Udev"
+msgstr ""
+
+#. Do not translate
+msgctxt "#30008"
+msgid "SDL 2"
+msgstr ""
+
+#msgctxt "#21475"
+#msgid "Both"
+#msgstr ""

--- a/peripheral.joystick/resources/settings.xml.include
+++ b/peripheral.joystick/resources/settings.xml.include
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<settings>
+	<category label="30000">
+		@LINUX_SELECT@
+		@SDL_SELECT@
+		@OSX_SELECT@
+		@XINPUT_CHECK@
+		@DIRECTINPUT_CHECK@
+	</category>
+</settings>

--- a/src/api/IJoystickInterface.cpp
+++ b/src/api/IJoystickInterface.cpp
@@ -26,8 +26,3 @@ std::string IJoystickInterface::Provider(void) const
 {
   return JoystickTranslator::GetInterfaceProvider(Type());
 }
-
-std::string IJoystickInterface::Name(void) const
-{
-  return JoystickTranslator::GetInterfaceName(Type());
-}

--- a/src/api/IJoystickInterface.cpp
+++ b/src/api/IJoystickInterface.cpp
@@ -1,6 +1,6 @@
 /*
- *      Copyright (C) 2014-2017 Garrett Brown
- *      Copyright (C) 2014-2017 Team Kodi
+ *      Copyright (C) 2017 Garrett Brown
+ *      Copyright (C) 2017 Team XBMC
  *
  *  This Program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -15,25 +15,19 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this Program; see the file COPYING.  If not, see
  *  <http://www.gnu.org/licenses/>.
- *
  */
-#pragma once
 
-#include "api/IJoystickInterface.h"
+#include "IJoystickInterface.h"
+#include "JoystickTranslator.h"
 
-#include <stdint.h>
-#include <string>
+using namespace JOYSTICK;
 
-namespace JOYSTICK
+std::string IJoystickInterface::Provider(void) const
 {
-  class CJoystickInterfaceLinux : public IJoystickInterface
-  {
-  public:
-    CJoystickInterfaceLinux(void) { }
-    virtual ~CJoystickInterfaceLinux(void) { }
+  return JoystickTranslator::GetInterfaceProvider(Type());
+}
 
-    // implementation of IJoystickInterface
-    virtual EJoystickInterface Type(void) const override;
-    virtual bool ScanForJoysticks(JoystickVector& joysticks) override;
-  };
+std::string IJoystickInterface::Name(void) const
+{
+  return JoystickTranslator::GetInterfaceName(Type());
 }

--- a/src/api/IJoystickInterface.h
+++ b/src/api/IJoystickInterface.h
@@ -36,7 +36,17 @@ namespace JOYSTICK
     /*!
      * \brief Get a short name for the interface
      */
-    virtual const char* Name(void) const = 0;
+    virtual EJoystickInterface Type(void) const = 0;
+
+    /*!
+     * \brief Convenience function to translate interface type to provider string
+     */
+    std::string Provider(void) const;
+
+    /*!
+     * \brief Convenience function to translate interface type to name string
+     */
+    std::string Name(void) const;
 
     /*!
      * \brief Initialize the interface

--- a/src/api/IJoystickInterface.h
+++ b/src/api/IJoystickInterface.h
@@ -44,11 +44,6 @@ namespace JOYSTICK
     std::string Provider(void) const;
 
     /*!
-     * \brief Convenience function to translate interface type to name string
-     */
-    std::string Name(void) const;
-
-    /*!
      * \brief Initialize the interface
      */
     virtual bool Initialize(void) { return true; }

--- a/src/api/Joystick.cpp
+++ b/src/api/Joystick.cpp
@@ -137,7 +137,10 @@ void CJoystick::Activate()
     m_activateTimeMs = P8PLATFORM::GetTimeMs();
 
     if (CJoystickUtils::IsGhostJoystick(*this))
+    {
+      CJoystickManager::Get().SetChanged(true);
       CJoystickManager::Get().TriggerScan();
+    }
   }
 }
 

--- a/src/api/Joystick.cpp
+++ b/src/api/Joystick.cpp
@@ -19,7 +19,9 @@
  */
 
 #include "Joystick.h"
+#include "JoystickManager.h"
 #include "JoystickTranslator.h"
+#include "JoystickUtils.h"
 #include "log/Log.h"
 #include "settings/Settings.h"
 #include "utils/CommonMacros.h"
@@ -128,6 +130,17 @@ bool CJoystick::SendEvent(const ADDON::PeripheralEvent& event)
   return bHandled;
 }
 
+void CJoystick::Activate()
+{
+  if (!IsActive())
+  {
+    m_activateTimeMs = P8PLATFORM::GetTimeMs();
+
+    if (CJoystickUtils::IsGhostJoystick(*this))
+      CJoystickManager::Get().TriggerScan();
+  }
+}
+
 void CJoystick::GetButtonEvents(std::vector<ADDON::PeripheralEvent>& events)
 {
   const std::vector<JOYSTICK_STATE_BUTTON>& buttons = m_stateBuffer.buttons;
@@ -169,8 +182,7 @@ void CJoystick::GetAxisEvents(std::vector<ADDON::PeripheralEvent>& events)
 
 void CJoystick::SetButtonValue(unsigned int buttonIndex, JOYSTICK_STATE_BUTTON buttonValue)
 {
-  if (m_activateTimeMs < 0)
-    m_activateTimeMs = P8PLATFORM::GetTimeMs();
+  Activate();
 
   if (buttonIndex < m_stateBuffer.buttons.size())
     m_stateBuffer.buttons[buttonIndex] = buttonValue;
@@ -178,8 +190,7 @@ void CJoystick::SetButtonValue(unsigned int buttonIndex, JOYSTICK_STATE_BUTTON b
 
 void CJoystick::SetHatValue(unsigned int hatIndex, JOYSTICK_STATE_HAT hatValue)
 {
-  if (m_activateTimeMs < 0)
-    m_activateTimeMs = P8PLATFORM::GetTimeMs();
+  Activate();
 
   if (hatIndex < m_stateBuffer.hats.size())
     m_stateBuffer.hats[hatIndex] = hatValue;
@@ -187,8 +198,7 @@ void CJoystick::SetHatValue(unsigned int hatIndex, JOYSTICK_STATE_HAT hatValue)
 
 void CJoystick::SetAxisValue(unsigned int axisIndex, JOYSTICK_STATE_AXIS axisValue)
 {
-  if (m_activateTimeMs < 0)
-    m_activateTimeMs = P8PLATFORM::GetTimeMs();
+  Activate();
 
   axisValue = CONSTRAIN(-1.0f, axisValue, 1.0f);
 

--- a/src/api/Joystick.cpp
+++ b/src/api/Joystick.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "Joystick.h"
+#include "JoystickTranslator.h"
 #include "log/Log.h"
 #include "settings/Settings.h"
 #include "utils/CommonMacros.h"
@@ -30,13 +31,13 @@ using namespace JOYSTICK;
 
 #define ANALOG_EPSILON  0.0001f
 
-CJoystick::CJoystick(const std::string& strProvider)
+CJoystick::CJoystick(EJoystickInterface interfaceType)
  : m_discoverTimeMs(P8PLATFORM::GetTimeMs()),
    m_activateTimeMs(-1),
    m_firstEventTimeMs(-1),
    m_lastEventTimeMs(-1)
 {
-  SetProvider(strProvider);
+  SetProvider(JoystickTranslator::GetInterfaceProvider(interfaceType));
 }
 
 bool CJoystick::Equals(const CJoystick* rhs) const

--- a/src/api/Joystick.h
+++ b/src/api/Joystick.h
@@ -19,6 +19,8 @@
  */
 #pragma once
 
+#include "JoystickTypes.h"
+
 #include "kodi_peripheral_utils.hpp"
 
 #include <string>
@@ -29,7 +31,8 @@ namespace JOYSTICK
   class CJoystick : public ADDON::Joystick
   {
   public:
-    CJoystick(const std::string& strProvider);
+    CJoystick(EJoystickInterface interfaceType);
+
     virtual ~CJoystick(void) { Deinitialize(); }
 
     /*!

--- a/src/api/Joystick.h
+++ b/src/api/Joystick.h
@@ -56,6 +56,11 @@ namespace JOYSTICK
     int64_t ActivateTimeMs(void) const { return m_activateTimeMs; }
 
     /*!
+     * Check if this joystick has received any input
+     */
+    bool IsActive(void) const { return m_activateTimeMs >= 0; }
+
+    /*!
      * The time that this joystick delivered its first event
      */
     int64_t FirstEventTimeMs(void) const { return m_firstEventTimeMs; }
@@ -111,6 +116,8 @@ namespace JOYSTICK
     void SetAxisValue(unsigned int axisIndex, long value, long maxAxisAmount);
 
   private:
+    void Activate();
+
     void GetButtonEvents(std::vector<ADDON::PeripheralEvent>& events);
     void GetHatEvents(std::vector<ADDON::PeripheralEvent>& events);
     void GetAxisEvents(std::vector<ADDON::PeripheralEvent>& events);

--- a/src/api/JoystickManager.cpp
+++ b/src/api/JoystickManager.cpp
@@ -22,6 +22,7 @@
 #include "IJoystickInterface.h"
 #include "Joystick.h"
 #include "JoystickTranslator.h"
+#include "JoystickUtils.h"
 
 #if defined(HAVE_DIRECT_INPUT)
   #include "directinput/JoystickInterfaceDirectInput.h"
@@ -228,11 +229,8 @@ bool CJoystickManager::PerformJoystickScan(JoystickVector& joysticks)
   joysticks.erase(std::remove_if(joysticks.begin(), joysticks.end(),
     [](const JoystickPtr& joystick)
     {
-      return (joystick->Provider() == JoystickTranslator::GetInterfaceProvider(EJoystickInterface::LINUX) ||
-               joystick->Provider() == JoystickTranslator::GetInterfaceProvider(EJoystickInterface::UDEV)) &&
-             (joystick->Name() == "Xbox 360 Wireless Receiver" ||
-               joystick->Name() == "Xbox 360 Wireless Receiver (XBOX)") &&
-             joystick->ActivateTimeMs() < 0;
+      return CJoystickUtils::IsGhostJoystick(*joystick) &&
+             !joystick->IsActive();
     }), joysticks.end());
 
   return true;

--- a/src/api/JoystickManager.cpp
+++ b/src/api/JoystickManager.cpp
@@ -44,6 +44,7 @@
 #endif
 
 #include "log/Log.h"
+#include "settings/Settings.h"
 #include "utils/CommonMacros.h"
 
 #include <algorithm>
@@ -92,7 +93,8 @@ namespace JOYSTICK
 
 CJoystickManager::CJoystickManager(void)
   : m_scanner(NULL),
-    m_nextJoystickIndex(0)
+    m_nextJoystickIndex(0),
+    m_bChanged(false)
 {
 }
 
@@ -102,47 +104,86 @@ CJoystickManager& CJoystickManager::Get(void)
   return _instance;
 }
 
+const std::vector<EJoystickInterface>& CJoystickManager::GetSupportedInterfaces()
+{
+  static std::vector<EJoystickInterface> supportedInterfaces;
+
+  // Supported interfaces in order of priority
+  if (supportedInterfaces.empty())
+  {
+#if defined(HAVE_DIRECT_INPUT)
+    supportedInterfaces.push_back(EJoystickInterface::DIRECTINPUT);
+#endif
+#if defined(HAVE_XINPUT)
+    supportedInterfaces.push_back(EJoystickInterface::XINPUT);
+#endif
+
+  // Linux
+#if defined(HAVE_SDL)
+    supportedInterfaces.push_back(EJoystickInterface::SDL);
+#endif
+#if defined(HAVE_LINUX_JOYSTICK)
+    supportedInterfaces.push_back(EJoystickInterface::LINUX);
+#endif
+#if defined(HAVE_UDEV)
+    supportedInterfaces.push_back(EJoystickInterface::UDEV);
+#endif
+
+  // OSX
+#if defined(HAVE_COCOA)
+    supportedInterfaces.push_back(EJoystickInterface::COCOA);
+#endif
+  }
+
+  return supportedInterfaces;
+}
+
+IJoystickInterface* CJoystickManager::CreateInterface(EJoystickInterface interface)
+{
+  switch (interface)
+  {
+#if defined(HAVE_COCOA)
+  case EJoystickInterface::COCOA: return new CJoystickInterfaceCocoa;
+#endif
+#if defined(HAVE_DIRECT_INPUT)
+  case EJoystickInterface::DIRECTINPUT: return new CJoystickInterfaceDirectInput;
+#endif
+#if defined(HAVE_LINUX_JOYSTICK)
+  case EJoystickInterface::LINUX: return new CJoystickInterfaceLinux;
+#endif
+#if defined(HAVE_SDL)
+  case EJoystickInterface::SDL: return new CJoystickInterfaceSDL;
+#endif
+#if defined(HAVE_UDEV)
+  case EJoystickInterface::UDEV: return new CJoystickInterfaceUdev;
+#endif
+#if defined(HAVE_XINPUT)
+  case EJoystickInterface::XINPUT: return new CJoystickInterfaceXInput;
+#endif
+  default:
+    break;
+  }
+
+  return nullptr;
+}
+
 bool CJoystickManager::Initialize(IScannerCallback* scanner)
 {
   CLockObject lock(m_interfacesMutex);
 
   m_scanner = scanner;
 
-  // Windows
-#if defined(HAVE_DIRECT_INPUT)
-  m_interfaces.push_back(new CJoystickInterfaceDirectInput);
-#endif
-#if defined(HAVE_XINPUT)
-  m_interfaces.push_back(new CJoystickInterfaceXInput);
-#endif
+  const std::vector<EJoystickInterface>& interfaces = GetSupportedInterfaces();
 
-  // Linux
-#if defined(HAVE_SDL)
-  m_interfaces.push_back(new CJoystickInterfaceSDL);
-#elif defined(HAVE_LINUX_JOYSTICK)
-  m_interfaces.push_back(new CJoystickInterfaceLinux);
-#elif defined(HAVE_UDEV)
-  m_interfaces.push_back(new CJoystickInterfaceUdev);
-#endif
-
-  // OSX
-#if defined(HAVE_COCOA)
-  m_interfaces.push_back(new CJoystickInterfaceCocoa);
-#endif
+  for (auto interface : interfaces)
+  {
+    auto iface = CreateInterface(interface);
+    if (iface)
+      m_interfaces.push_back(iface);
+  }
 
   if (m_interfaces.empty())
     dsyslog("No joystick APIs in use");
-
-  // Initialise all known interfaces
-  for (int i = (int)m_interfaces.size() - 1; i >= 0; i--)
-  {
-    if (!m_interfaces.at(i)->Initialize())
-    {
-      esyslog("Failed to initialize interface %s", JoystickTranslator::GetInterfaceName(m_interfaces.at(i)->Type()).c_str());
-      delete m_interfaces.at(i);
-      m_interfaces.erase(m_interfaces.begin() + i);
-    }
-  }
 
   return true;
 }
@@ -156,6 +197,8 @@ void CJoystickManager::Deinitialize(void)
 
   {
     CLockObject lock(m_interfacesMutex);
+    for (auto iface : m_interfaces)
+      SetEnabled(iface->Type(), false);
     safe_delete_vector(m_interfaces);
   }
 
@@ -165,7 +208,7 @@ void CJoystickManager::Deinitialize(void)
 bool CJoystickManager::SupportsRumble(void) const
 {
   CLockObject lock(m_interfacesMutex);
-  for (auto iface : m_interfaces)
+  for (auto iface : m_enabledInterfaces)
   {
     if (iface->SupportsRumble())
       return true;
@@ -177,7 +220,7 @@ bool CJoystickManager::SupportsRumble(void) const
 bool CJoystickManager::SupportsPowerOff(void) const
 {
   CLockObject lock(m_interfacesMutex);
-  for (auto iface : m_interfaces)
+  for (auto iface : m_enabledInterfaces)
   {
     if (iface->SupportsPowerOff())
       return true;
@@ -186,14 +229,63 @@ bool CJoystickManager::SupportsPowerOff(void) const
   return false;
 }
 
+bool CJoystickManager::HasInterface(EJoystickInterface interface) const
+{
+  CLockObject lock(m_interfacesMutex);
+  for (auto iface : m_interfaces)
+  {
+    if (iface->Type() == interface)
+      return true;
+  }
+
+  return false;
+}
+
+void CJoystickManager::SetEnabled(EJoystickInterface interface, bool bEnabled)
+{
+  CLockObject lock(m_interfacesMutex);
+
+  for (auto iface : m_interfaces)
+  {
+    if (iface->Type() == interface)
+    {
+      if (bEnabled && !IsEnabled(iface))
+      {
+        isyslog("Enabling joystick interface \"%s\"", JoystickTranslator::GetInterfaceProvider(interface).c_str());
+        if (iface->Initialize())
+        {
+          m_enabledInterfaces.insert(iface);
+          SetChanged(true);
+        }
+        else
+          esyslog("Failed to initialize interface %s", JoystickTranslator::GetInterfaceProvider(interface).c_str());
+      }
+      else if (!bEnabled && IsEnabled(iface))
+      {
+        isyslog("Disabling joystick interface \"%s\"", JoystickTranslator::GetInterfaceProvider(interface).c_str());
+        iface->Deinitialize();
+        m_enabledInterfaces.erase(iface);
+        SetChanged(true);
+      }
+      break;
+    }
+  }
+}
+
+bool CJoystickManager::IsEnabled(IJoystickInterface* interface)
+{
+  CLockObject lock(m_interfacesMutex);
+  return m_enabledInterfaces.find(interface) != m_enabledInterfaces.end();
+}
+
 bool CJoystickManager::PerformJoystickScan(JoystickVector& joysticks)
 {
   JoystickVector scanResults;
   {
     CLockObject lock(m_interfacesMutex);
     // Scan for joysticks (this can take a while, don't block)
-    for (std::vector<IJoystickInterface*>::iterator itInterface = m_interfaces.begin(); itInterface != m_interfaces.end(); ++itInterface)
-      (*itInterface)->ScanForJoysticks(scanResults);
+    for (auto interface : m_enabledInterfaces)
+      interface->ScanForJoysticks(scanResults);
   }
 
   CLockObject lock(m_joystickMutex);
@@ -304,9 +396,22 @@ void CJoystickManager::ProcessEvents()
     joystick->ProcessEvents();
 }
 
+void CJoystickManager::SetChanged(bool bChanged)
+{
+  CLockObject lock(m_changedMutex);
+  m_bChanged = bChanged;
+}
+
 void CJoystickManager::TriggerScan(void)
 {
-  if (m_scanner)
+  bool bChanged;
+  {
+    CLockObject lock(m_changedMutex);
+    bChanged = m_bChanged;
+    m_bChanged = false;
+  }
+
+  if (bChanged && m_scanner)
     m_scanner->TriggerScan();
 }
 

--- a/src/api/JoystickManager.cpp
+++ b/src/api/JoystickManager.cpp
@@ -21,6 +21,7 @@
 #include "JoystickManager.h"
 #include "IJoystickInterface.h"
 #include "Joystick.h"
+#include "JoystickTranslator.h"
 
 #if defined(HAVE_DIRECT_INPUT)
   #include "directinput/JoystickInterfaceDirectInput.h"
@@ -45,6 +46,7 @@
 #include "utils/CommonMacros.h"
 
 #include <algorithm>
+#include <iterator>
 
 using namespace JOYSTICK;
 using namespace P8PLATFORM;
@@ -135,7 +137,7 @@ bool CJoystickManager::Initialize(IScannerCallback* scanner)
   {
     if (!m_interfaces.at(i)->Initialize())
     {
-      esyslog("Failed to initialize interface %s", m_interfaces.at(i)->Name());
+      esyslog("Failed to initialize interface %s", JoystickTranslator::GetInterfaceName(m_interfaces.at(i)->Type()).c_str());
       delete m_interfaces.at(i);
       m_interfaces.erase(m_interfaces.begin() + i);
     }
@@ -226,8 +228,8 @@ bool CJoystickManager::PerformJoystickScan(JoystickVector& joysticks)
   joysticks.erase(std::remove_if(joysticks.begin(), joysticks.end(),
     [](const JoystickPtr& joystick)
     {
-      return (joystick->Provider() == INTERFACE_LINUX ||
-               joystick->Provider() == INTERFACE_UDEV) &&
+      return (joystick->Provider() == JoystickTranslator::GetInterfaceProvider(EJoystickInterface::LINUX) ||
+               joystick->Provider() == JoystickTranslator::GetInterfaceProvider(EJoystickInterface::UDEV)) &&
              (joystick->Name() == "Xbox 360 Wireless Receiver" ||
                joystick->Name() == "Xbox 360 Wireless Receiver (XBOX)") &&
              joystick->ActivateTimeMs() < 0;
@@ -319,7 +321,7 @@ const ButtonMap& CJoystickManager::GetButtonMap(const std::string& provider)
   // Scan for joysticks (this can take a while, don't block)
   for (std::vector<IJoystickInterface*>::iterator itInterface = m_interfaces.begin(); itInterface != m_interfaces.end(); ++itInterface)
   {
-    if ((*itInterface)->Name() == provider)
+    if ((*itInterface)->Provider() == provider)
       return (*itInterface)->GetButtonMap();
   }
 

--- a/src/api/JoystickManager.h
+++ b/src/api/JoystickManager.h
@@ -25,6 +25,7 @@
 #include "kodi_peripheral_utils.hpp"
 #include "p8-platform/threads/mutex.h"
 
+#include <set>
 #include <vector>
 
 namespace JOYSTICK
@@ -51,6 +52,10 @@ namespace JOYSTICK
     static CJoystickManager& Get(void);
     virtual ~CJoystickManager(void) { Deinitialize(); }
 
+    static const std::vector<EJoystickInterface>& GetSupportedInterfaces();
+
+    static IJoystickInterface* CreateInterface(EJoystickInterface interface);
+
     /*!
      * \brief Initialize the joystick manager
      *
@@ -72,6 +77,32 @@ namespace JOYSTICK
      * \brief Return true if an interface supports controller power-off
      */
     bool SupportsPowerOff(void) const;
+
+    /*!
+     * \brief Check if the given interface is managed by this system
+     *
+     * \param interface The interface type
+     *
+     * \return true if the interface is present
+     */
+    bool HasInterface(EJoystickInterface interface) const;
+
+    /*!
+     * \brief Set the state of the specified interface
+     *
+     * \param iface The interface type
+     * \param bEnabled True to enable interface, false to disable interface
+     */
+    void SetEnabled(EJoystickInterface interface, bool bEnabled);
+
+    /*!
+     * \brief Check the state of the specified interface
+     *
+     * \param interface The interface to check
+     *
+     * \return true if the interface is present and enabled, false otherwise
+     */
+    bool IsEnabled(IJoystickInterface* interface);
 
     /*!
      * \brief Scan the available interfaces for joysticks
@@ -106,7 +137,12 @@ namespace JOYSTICK
     void ProcessEvents();
 
     /*!
-     * \brief Trigger a scan for joysticks through the callback
+     * \brief Set the flag for changed interfaces
+     */
+    void SetChanged(bool bChanged);
+
+    /*!
+     * \brief Trigger a scan for joysticks through the callback, if changed
      */
     void TriggerScan(void);
 
@@ -122,8 +158,11 @@ namespace JOYSTICK
   private:
     IScannerCallback*                m_scanner;
     std::vector<IJoystickInterface*> m_interfaces;
+    std::set<IJoystickInterface*>    m_enabledInterfaces;
     JoystickVector                   m_joysticks;
     unsigned int                     m_nextJoystickIndex;
+    bool                             m_bChanged;
+    mutable P8PLATFORM::CMutex       m_changedMutex;
     mutable P8PLATFORM::CMutex         m_interfacesMutex;
     mutable P8PLATFORM::CMutex         m_joystickMutex;
   };

--- a/src/api/JoystickManager.h
+++ b/src/api/JoystickManager.h
@@ -54,7 +54,7 @@ namespace JOYSTICK
 
     static const std::vector<EJoystickInterface>& GetSupportedInterfaces();
 
-    static IJoystickInterface* CreateInterface(EJoystickInterface interface);
+    static IJoystickInterface* CreateInterface(EJoystickInterface iface);
 
     /*!
      * \brief Initialize the joystick manager
@@ -81,11 +81,11 @@ namespace JOYSTICK
     /*!
      * \brief Check if the given interface is managed by this system
      *
-     * \param interface The interface type
+     * \param iface The interface type
      *
      * \return true if the interface is present
      */
-    bool HasInterface(EJoystickInterface interface) const;
+    bool HasInterface(EJoystickInterface iface) const;
 
     /*!
      * \brief Set the state of the specified interface
@@ -93,16 +93,16 @@ namespace JOYSTICK
      * \param iface The interface type
      * \param bEnabled True to enable interface, false to disable interface
      */
-    void SetEnabled(EJoystickInterface interface, bool bEnabled);
+    void SetEnabled(EJoystickInterface iface, bool bEnabled);
 
     /*!
      * \brief Check the state of the specified interface
      *
-     * \param interface The interface to check
+     * \param iface The interface to check
      *
      * \return true if the interface is present and enabled, false otherwise
      */
-    bool IsEnabled(IJoystickInterface* interface);
+    bool IsEnabled(IJoystickInterface* iface);
 
     /*!
      * \brief Scan the available interfaces for joysticks

--- a/src/api/JoystickTranslator.cpp
+++ b/src/api/JoystickTranslator.cpp
@@ -20,7 +20,84 @@
 
 #include "JoystickTranslator.h"
 
+#include <algorithm>
+
 using namespace JOYSTICK;
+
+namespace JOYSTICK
+{
+  struct SJoystickInterface
+  {
+    EJoystickInterface type;
+    const char* provider;
+    const char* name;
+  };
+
+  static const std::vector<SJoystickInterface> Interfaces =
+  {
+    {
+      EJoystickInterface::COCOA,
+      "cocoa", "Cocoa",
+    },
+    {
+      EJoystickInterface::DIRECTINPUT,
+      "directinput", "DirectInput",
+    },
+    {
+      EJoystickInterface::LINUX,
+      "linux", "Linux Joystick API",
+    },
+    {
+      EJoystickInterface::SDL,
+      "sdl", "SDL 2",
+    },
+    {
+      EJoystickInterface::UDEV,
+      "udev", "udev",
+    },
+    {
+      EJoystickInterface::XINPUT,
+      "xinput", "XInput",
+    },
+  };
+
+  struct FindByType
+  {
+    FindByType(EJoystickInterface type) : m_type(type) { }
+
+    bool operator()(const SJoystickInterface& iface)
+    {
+      return iface.type == m_type;
+    }
+
+  private:
+    EJoystickInterface m_type;
+  };
+}
+
+// --- JoystickTranslator ------------------------------------------------------
+
+std::string JoystickTranslator::GetInterfaceProvider(EJoystickInterface iface)
+{
+  std::string provider;
+
+  auto it = std::find_if(Interfaces.begin(), Interfaces.end(), FindByType(iface));
+  if (it != Interfaces.end())
+    provider = it->provider;
+
+  return provider;
+}
+
+std::string JoystickTranslator::GetInterfaceName(EJoystickInterface iface)
+{
+  std::string name;
+
+  auto it = std::find_if(Interfaces.begin(), Interfaces.end(), FindByType(iface));
+  if (it != Interfaces.end())
+    name = it->name;
+
+  return name;
+}
 
 JOYSTICK_DRIVER_HAT_DIRECTION JoystickTranslator::TranslateHatDir(const std::string& hatDir)
 {

--- a/src/api/JoystickTranslator.cpp
+++ b/src/api/JoystickTranslator.cpp
@@ -30,34 +30,33 @@ namespace JOYSTICK
   {
     EJoystickInterface type;
     const char* provider;
-    const char* name;
   };
 
   static const std::vector<SJoystickInterface> Interfaces =
   {
     {
       EJoystickInterface::COCOA,
-      "cocoa", "Cocoa",
+      "cocoa",
     },
     {
       EJoystickInterface::DIRECTINPUT,
-      "directinput", "DirectInput",
+      "directinput",
     },
     {
       EJoystickInterface::LINUX,
-      "linux", "Linux Joystick API",
+      "linux",
     },
     {
       EJoystickInterface::SDL,
-      "sdl", "SDL 2",
+      "sdl",
     },
     {
       EJoystickInterface::UDEV,
-      "udev", "udev",
+      "udev",
     },
     {
       EJoystickInterface::XINPUT,
-      "xinput", "XInput",
+      "xinput",
     },
   };
 
@@ -72,6 +71,19 @@ namespace JOYSTICK
 
   private:
     EJoystickInterface m_type;
+  };
+
+  struct FindByProvider
+  {
+    FindByProvider(const std::string& provider) : m_provider(provider) { }
+
+    bool operator()(const SJoystickInterface& iface)
+    {
+      return iface.provider == m_provider;
+    }
+
+  private:
+    const std::string m_provider;
   };
 }
 
@@ -88,15 +100,15 @@ std::string JoystickTranslator::GetInterfaceProvider(EJoystickInterface iface)
   return provider;
 }
 
-std::string JoystickTranslator::GetInterfaceName(EJoystickInterface iface)
+EJoystickInterface JoystickTranslator::GetInterfaceType(const std::string& provider)
 {
-  std::string name;
+  EJoystickInterface type = EJoystickInterface::NONE;
 
-  auto it = std::find_if(Interfaces.begin(), Interfaces.end(), FindByType(iface));
+  auto it = std::find_if(Interfaces.begin(), Interfaces.end(), FindByProvider(provider));
   if (it != Interfaces.end())
-    name = it->name;
+    type = it->type;
 
-  return name;
+  return type;
 }
 
 JOYSTICK_DRIVER_HAT_DIRECTION JoystickTranslator::TranslateHatDir(const std::string& hatDir)

--- a/src/api/JoystickTranslator.h
+++ b/src/api/JoystickTranslator.h
@@ -31,7 +31,7 @@ namespace JOYSTICK
   {
   public:
     static std::string GetInterfaceProvider(EJoystickInterface iface);
-    static std::string GetInterfaceName(EJoystickInterface iface);
+    static EJoystickInterface GetInterfaceType(const std::string& provider);
 
     static JOYSTICK_DRIVER_HAT_DIRECTION TranslateHatDir(const std::string& hatDir);
     static const char* TranslateHatDir(JOYSTICK_DRIVER_HAT_DIRECTION hatDir);

--- a/src/api/JoystickTranslator.h
+++ b/src/api/JoystickTranslator.h
@@ -19,6 +19,8 @@
  */
 #pragma once
 
+#include "JoystickTypes.h"
+
 #include "kodi_peripheral_types.h"
 
 #include <string>
@@ -28,6 +30,9 @@ namespace JOYSTICK
   class JoystickTranslator
   {
   public:
+    static std::string GetInterfaceProvider(EJoystickInterface iface);
+    static std::string GetInterfaceName(EJoystickInterface iface);
+
     static JOYSTICK_DRIVER_HAT_DIRECTION TranslateHatDir(const std::string& hatDir);
     static const char* TranslateHatDir(JOYSTICK_DRIVER_HAT_DIRECTION hatDir);
 

--- a/src/api/JoystickTypes.h
+++ b/src/api/JoystickTypes.h
@@ -22,15 +22,23 @@
 #include <memory>
 #include <vector>
 
-#define INTERFACE_COCOA        "cocoa"
-#define INTERFACE_DIRECTINPUT  "directinput"
-#define INTERFACE_LINUX        "linux"
-#define INTERFACE_SDL          "sdl"
-#define INTERFACE_UDEV         "udev"
-#define INTERFACE_XINPUT       "xinput"
-
 namespace JOYSTICK
 {
+  /*!
+   * \brief Joystick interface types
+   *
+   * Priority of interfaces is determined by JoystickUtils::GetDrivers().
+   */
+  enum class EJoystickInterface
+  {
+    COCOA,
+    DIRECTINPUT,
+    LINUX,
+    SDL,
+    UDEV,
+    XINPUT,
+  };
+
   class CJoystick;
   typedef std::shared_ptr<CJoystick> JoystickPtr;
   typedef std::vector<JoystickPtr>   JoystickVector;

--- a/src/api/JoystickTypes.h
+++ b/src/api/JoystickTypes.h
@@ -31,6 +31,7 @@ namespace JOYSTICK
    */
   enum class EJoystickInterface
   {
+    NONE,
     COCOA,
     DIRECTINPUT,
     LINUX,

--- a/src/api/JoystickUtils.cpp
+++ b/src/api/JoystickUtils.cpp
@@ -1,0 +1,42 @@
+/*
+ *      Copyright (C) 2017 Garrett Brown
+ *      Copyright (C) 2017 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ */
+
+#include "JoystickUtils.h"
+#include "Joystick.h"
+#include "JoystickTranslator.h"
+#include "JoystickTypes.h"
+
+using namespace JOYSTICK;
+
+bool CJoystickUtils::IsGhostJoystick(const CJoystick& joystick)
+{
+  // Ghost joysticks observed on linux and udev
+  if (joystick.Provider() == JoystickTranslator::GetInterfaceProvider(EJoystickInterface::LINUX) ||
+      joystick.Provider() == JoystickTranslator::GetInterfaceProvider(EJoystickInterface::UDEV))
+  {
+    // Wireless receiver names
+    if (joystick.Name() == "Xbox 360 Wireless Receiver" ||
+        joystick.Name() == "Xbox 360 Wireless Receiver (XBOX)")
+    {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/api/JoystickUtils.h
+++ b/src/api/JoystickUtils.h
@@ -1,0 +1,34 @@
+/*
+ *      Copyright (C) 2017 Garrett Brown
+ *      Copyright (C) 2017 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+namespace JOYSTICK
+{
+  class CJoystick;
+
+  class CJoystickUtils
+  {
+  public:
+    /*!
+     * \brief Check if joystick belongs to a wireless receiver that always
+     *        reports a joystick attached, even though none is present
+     */
+    static bool IsGhostJoystick(const CJoystick& joystick);
+  };
+}

--- a/src/api/cocoa/JoystickCocoa.cpp
+++ b/src/api/cocoa/JoystickCocoa.cpp
@@ -30,7 +30,7 @@ using namespace P8PLATFORM;
 #define MAX_JOYSTICK_BUTTONS  512
 
 CJoystickCocoa::CJoystickCocoa(IOHIDDeviceRef device, CJoystickInterfaceCocoa* api)
- : CJoystick(INTERFACE_COCOA),
+ : CJoystick(EJoystickInterface::COCOA),
    m_api(api),
    m_device(device),
    m_bInitialized(false)

--- a/src/api/cocoa/JoystickInterfaceCocoa.cpp
+++ b/src/api/cocoa/JoystickInterfaceCocoa.cpp
@@ -163,7 +163,10 @@ void CJoystickInterfaceCocoa::DeviceAdded(IOHIDDeviceRef device)
   }
 
   if (bDeviceAdded)
+  {
+    CJoystickManager::Get().SetChanged(true);
     CJoystickManager::Get().TriggerScan();
+  }
 }
 
 void CJoystickInterfaceCocoa::DeviceRemoved(IOHIDDeviceRef device)
@@ -173,6 +176,7 @@ void CJoystickInterfaceCocoa::DeviceRemoved(IOHIDDeviceRef device)
     m_discoveredDevices.erase(std::remove(m_discoveredDevices.begin(), m_discoveredDevices.end(), device), m_discoveredDevices.end());
   }
 
+  CJoystickManager::Get().SetChanged(true);
   CJoystickManager::Get().TriggerScan();
 }
 

--- a/src/api/cocoa/JoystickInterfaceCocoa.cpp
+++ b/src/api/cocoa/JoystickInterfaceCocoa.cpp
@@ -69,9 +69,9 @@ CJoystickInterfaceCocoa::CJoystickInterfaceCocoa(void)
 {
 }
 
-const char* CJoystickInterfaceCocoa::Name(void) const
+EJoystickInterface CJoystickInterfaceCocoa::Type(void) const
 {
-  return INTERFACE_COCOA;
+  return EJoystickInterface::COCOA;
 }
 
 bool CJoystickInterfaceCocoa::Initialize(void)

--- a/src/api/cocoa/JoystickInterfaceCocoa.h
+++ b/src/api/cocoa/JoystickInterfaceCocoa.h
@@ -57,7 +57,7 @@ namespace JOYSTICK
     virtual ~CJoystickInterfaceCocoa(void) { Deinitialize(); }
 
     // implementation of IJoystickInterface
-    virtual const char* Name(void) const override;
+    virtual EJoystickInterface Type(void) const override;
     virtual bool Initialize(void) override;
     virtual void Deinitialize(void) override;
     virtual bool ScanForJoysticks(JoystickVector& joysticks) override;

--- a/src/api/directinput/JoystickDirectInput.cpp
+++ b/src/api/directinput/JoystickDirectInput.cpp
@@ -38,7 +38,7 @@ using namespace JOYSTICK;
 CJoystickDirectInput::CJoystickDirectInput(GUID                           deviceGuid,
                                            LPDIRECTINPUTDEVICE8           joystickDevice,
                                            const std::string&             strName)
- : CJoystick(INTERFACE_DIRECTINPUT),
+ : CJoystick(EJoystickInterface::DIRECTINPUT),
    m_deviceGuid(deviceGuid),
    m_joystickDevice(joystickDevice)
 {

--- a/src/api/directinput/JoystickInterfaceDirectInput.cpp
+++ b/src/api/directinput/JoystickInterfaceDirectInput.cpp
@@ -45,9 +45,9 @@ CJoystickInterfaceDirectInput::CJoystickInterfaceDirectInput(void)
     m_pDirectInput(NULL)
 { }
 
-const char* CJoystickInterfaceDirectInput::Name(void) const
+EJoystickInterface CJoystickInterfaceDirectInput::Type(void) const
 {
-  return INTERFACE_DIRECTINPUT;
+  return EJoystickInterface::DIRECTINPUT;
 }
 
 bool CJoystickInterfaceDirectInput::Initialize(void)

--- a/src/api/directinput/JoystickInterfaceDirectInput.h
+++ b/src/api/directinput/JoystickInterfaceDirectInput.h
@@ -35,7 +35,7 @@ namespace JOYSTICK
     virtual ~CJoystickInterfaceDirectInput(void) { Deinitialize(); }
 
     // implementation of IJoystickInterface
-    virtual const char* Name(void) const override;
+    virtual EJoystickInterface Type(void) const override;
     virtual bool Initialize(void) override;
     virtual void Deinitialize(void) override;
     virtual bool ScanForJoysticks(JoystickVector& joysticks) override;

--- a/src/api/linux/JoystickInterfaceLinux.cpp
+++ b/src/api/linux/JoystickInterfaceLinux.cpp
@@ -36,9 +36,9 @@
 
 using namespace JOYSTICK;
 
-const char* CJoystickInterfaceLinux::Name(void) const
+EJoystickInterface CJoystickInterfaceLinux::Type(void) const
 {
-  return INTERFACE_LINUX;
+  return EJoystickInterface::LINUX;
 }
 
 bool CJoystickInterfaceLinux::ScanForJoysticks(JoystickVector& joysticks)

--- a/src/api/linux/JoystickLinux.cpp
+++ b/src/api/linux/JoystickLinux.cpp
@@ -41,7 +41,7 @@ using namespace JOYSTICK;
 #define INVALID_FD         -1
 
 CJoystickLinux::CJoystickLinux(int fd, const std::string& strFilename)
- : CJoystick(INTERFACE_LINUX),
+ : CJoystick(EJoystickInterface::LINUX),
    m_fd(fd),
    m_strFilename(strFilename)
 {

--- a/src/api/sdl/JoystickInterfaceSDL.cpp
+++ b/src/api/sdl/JoystickInterfaceSDL.cpp
@@ -27,9 +27,9 @@
 
 using namespace JOYSTICK;
 
-const char* CJoystickInterfaceSDL::Name(void) const
+EJoystickInterface CJoystickInterfaceSDL::Type(void) const
 {
-  return INTERFACE_SDL;
+  return EJoystickInterface::SDL;
 }
 
 bool CJoystickInterfaceSDL::Initialize(void)

--- a/src/api/sdl/JoystickInterfaceSDL.h
+++ b/src/api/sdl/JoystickInterfaceSDL.h
@@ -31,7 +31,7 @@ namespace JOYSTICK
     virtual ~CJoystickInterfaceSDL(void) { Deinitialize(); }
 
     // Implementation of IJoystickInterface
-    virtual const char* Name(void) const override;
+    virtual EJoystickInterface Type(void) const override;
     virtual bool Initialize(void) override;
     virtual void Deinitialize(void) override;
     virtual bool ScanForJoysticks(JoystickVector& joysticks) override;

--- a/src/api/sdl/JoystickSDL.cpp
+++ b/src/api/sdl/JoystickSDL.cpp
@@ -30,7 +30,7 @@ using namespace JOYSTICK;
 #define MAX_AXIS      32768
 
 CJoystickSDL::CJoystickSDL(unsigned int index) :
-  CJoystick(INTERFACE_SDL),
+  CJoystick(EJoystickInterface::SDL),
   m_index(index),
   m_pController(nullptr)
 {

--- a/src/api/udev/JoystickInterfaceUdev.cpp
+++ b/src/api/udev/JoystickInterfaceUdev.cpp
@@ -44,9 +44,9 @@ CJoystickInterfaceUdev::CJoystickInterfaceUdev() :
 {
 }
 
-const char* CJoystickInterfaceUdev::Name() const
+EJoystickInterface CJoystickInterfaceUdev::Type() const
 {
-  return INTERFACE_UDEV;
+  return EJoystickInterface::UDEV;
 }
 
 bool CJoystickInterfaceUdev::Initialize()

--- a/src/api/udev/JoystickInterfaceUdev.h
+++ b/src/api/udev/JoystickInterfaceUdev.h
@@ -54,7 +54,7 @@ namespace JOYSTICK
     virtual ~CJoystickInterfaceUdev() { Deinitialize(); }
 
     // implementation of IJoystickInterface
-    virtual const char* Name() const override;
+    virtual EJoystickInterface Type() const override;
     virtual bool Initialize() override;
     virtual void Deinitialize() override;
     virtual bool SupportsRumble(void) const { return true; }

--- a/src/api/udev/JoystickUdev.cpp
+++ b/src/api/udev/JoystickUdev.cpp
@@ -46,7 +46,7 @@ using namespace JOYSTICK;
 #define NBITS(x)  ((((x) - 1) / (sizeof(long) * CHAR_BIT)) + 1)
 
 CJoystickUdev::CJoystickUdev(udev_device* dev, const char* path)
- : CJoystick(INTERFACE_UDEV),
+ : CJoystick(EJoystickInterface::UDEV),
    m_dev(dev),
    m_path(path),
    m_deviceNumber(0),

--- a/src/api/xinput/JoystickInterfaceXInput.cpp
+++ b/src/api/xinput/JoystickInterfaceXInput.cpp
@@ -24,15 +24,16 @@
 #include "api/JoystickTypes.h"
 
 #include <array>
+#include <cstring>
 #include <Xinput.h>
 
 using namespace JOYSTICK;
 
 #define MAX_JOYSTICKS 4
 
-const char* CJoystickInterfaceXInput::Name(void) const
+EJoystickInterface CJoystickInterfaceXInput::Type(void) const
 {
-  return INTERFACE_XINPUT;
+  return EJoystickInterface::XINPUT;
 }
 
 bool CJoystickInterfaceXInput::Initialize(void)

--- a/src/api/xinput/JoystickInterfaceXInput.h
+++ b/src/api/xinput/JoystickInterfaceXInput.h
@@ -30,7 +30,7 @@ namespace JOYSTICK
     virtual ~CJoystickInterfaceXInput(void) { Deinitialize(); }
 
     // Implementation of IJoystickInterface
-    virtual const char* Name(void) const override;
+    virtual EJoystickInterface Type(void) const override;
     virtual bool Initialize(void) override;
     virtual void Deinitialize(void) override;
     virtual bool SupportsRumble(void) const override { return true; }

--- a/src/api/xinput/JoystickXInput.cpp
+++ b/src/api/xinput/JoystickXInput.cpp
@@ -36,7 +36,7 @@ using namespace JOYSTICK;
 #define MAX_MOTOR     65535
 
 CJoystickXInput::CJoystickXInput(unsigned int controllerID)
- : CJoystick(INTERFACE_XINPUT),
+ : CJoystick(EJoystickInterface::XINPUT),
    m_controllerID(controllerID),
    m_dwPacketNumber(0)
 {

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -19,11 +19,19 @@
  */
 
 #include "Settings.h"
+#include "api/JoystickManager.h"
 #include "log/Log.h"
+
+#include <array>
 
 using namespace JOYSTICK;
 
-#define SETTING_RETROARCH_CONFIG  "retroarchconfig"
+#define SETTING_RETROARCH_CONFIG    "retroarchconfig"
+#define SETTING_LINUX_DRIVER        "driver_linux"
+#define SETTING_SDL_DRIVER          "driver_sdl"
+#define SETTING_OSX_DRIVER          "driver_osx"
+#define SETTING_XINPUT_DRIVER       "driver_xinput"
+#define SETTING_DIRECTINPUT_DRIVER  "driver_directinput"
 
 CSettings::CSettings(void)
   : m_bInitialized(false),
@@ -43,6 +51,63 @@ void CSettings::SetSetting(const std::string& strName, const void* value)
   {
     m_bGenerateRetroArchConfigs = *static_cast<const bool*>(value);
     dsyslog("Setting \"%s\" set to %f", SETTING_RETROARCH_CONFIG, m_bGenerateRetroArchConfigs ? "true" : "false");
+  }
+  else if (strName == SETTING_LINUX_DRIVER ||
+           strName == SETTING_SDL_DRIVER ||
+           strName == SETTING_OSX_DRIVER)
+  {
+    std::array<EJoystickInterface, 4> drivers;
+
+    if (strName == SETTING_LINUX_DRIVER)
+    {
+      drivers = {
+          EJoystickInterface::LINUX,
+          EJoystickInterface::UDEV,
+          EJoystickInterface::NONE,
+      };
+    }
+    else if (strName == SETTING_SDL_DRIVER)
+    {
+      drivers = {
+          EJoystickInterface::SDL,
+          EJoystickInterface::LINUX,
+          EJoystickInterface::UDEV,
+          EJoystickInterface::NONE,
+      };
+    }
+    else if (strName == SETTING_OSX_DRIVER)
+    {
+      drivers = {
+          EJoystickInterface::COCOA,
+          EJoystickInterface::NONE,
+      };
+    }
+
+    const char* strValue = static_cast<const char*>(value);
+    int ifaceIndex = strValue[0] - '0';
+
+    unsigned int driverIndex = 0;
+    for (auto driver : drivers)
+    {
+      if (driver == EJoystickInterface::NONE)
+        break;
+      CJoystickManager::Get().SetEnabled(driver, (driverIndex == ifaceIndex));
+      driverIndex++;
+    }
+
+    CJoystickManager::Get().TriggerScan();
+  }
+  else if (strName == SETTING_XINPUT_DRIVER)
+  {
+    const EJoystickInterface iface = EJoystickInterface::XINPUT;
+    CJoystickManager::Get().SetEnabled(iface, *static_cast<const bool*>(value));
+    CJoystickManager::Get().TriggerScan();
+  }
+  else if (strName == SETTING_DIRECTINPUT_DRIVER)
+  {
+    const EJoystickInterface iface = EJoystickInterface::DIRECTINPUT;
+    CJoystickManager::Get().SetEnabled(iface, *static_cast<const bool*>(value));
+    CJoystickManager::Get().TriggerScan();
   }
 
   m_bInitialized = true;


### PR DESCRIPTION
Also include two fixes:

* wireless Xbox controllers appearing late on linux
* windows build failures due to unicode switch

Corresponds to https://github.com/xbmc/xbmc/pull/11944