### PR TITLE
Fix settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,11 +227,56 @@ build_addon(peripheral.joystick JOYSTICK DEPLIBS)
 
 # ------------------------------------------------------------------------------
 
-set(LINUX_SELECT_LINE      "<setting label=\"30001\" type=\"select\" id=\"driver_linux\" lvalues=\"30005|30007|30002\"/>")
-set(SDL_SELECT_LINE        "<setting label=\"30001\" type=\"select\" id=\"driver_sdl\" lvalues=\"30008|30005|30007|30002\"/>")
-set(OSX_SELECT_LINE        "<setting label=\"30001\" type=\"select\" id=\"driver_linux\" lvalues=\"30006|30002\"/>")
-set(XINPUT_CHECK_LINE      "<setting label=\"30003\" type=\"bool\" id=\"driver_xinput\" default=\"true\"/>")
-set(DIRECTINPUT_CHECK_LINE "<setting label=\"30004\" type=\"bool\" id=\"driver_directinput\" default=\"true\"/>")
+set(LINUX_SELECT_LINE "\
+        <setting id=\"driver_linux\" type=\"integer\" label=\"30001\">
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label=\"30005\">0</option>
+              <option label=\"30007\">1</option>
+              <option label=\"30002\">2</option>
+            </options>
+          </constraints>
+          <control type=\"spinner\" format=\"string\"/>
+        </setting>")
+
+set(SDL_SELECT_LINE "\
+        <setting id=\"driver_sdl\" type=\"integer\" label=\"30001\">
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label=\"30008\">0</option>
+              <option label=\"30005\">1</option>
+              <option label=\"30007\">2</option>
+              <option label=\"30002\">3</option>
+            </options>
+          </constraints>
+          <control type=\"spinner\" format=\"string\"/>
+        </setting>")
+
+set(OSX_SELECT_LINE  "\
+        <setting id=\"driver_osx\" type=\"integer\" label=\"30001\">
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label=\"30006\">0</option>
+              <option label=\"30002\">1</option>
+            </options>
+          </constraints>
+          <control type=\"spinner\" format=\"string\"/>
+        </setting>")
+
+set(XINPUT_CHECK_LINE "\
+        <setting id=\"driver_xinput\" type=\"boolean\" label=\"30003\">
+          <default>true</default>
+          <control type=\"toggle\"/>
+        </setting>")
+
+set(DIRECTINPUT_CHECK_LINE "\
+        <setting id=\"driver_directinput\" type=\"boolean\" label=\"30004\">
+          <default>true</default>
+          <control type=\"toggle\"/>
+        </setting>")
 
 # Write settings.xml.include
 if(CORE_SYSTEM_NAME STREQUAL windows)

--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.3.6"
+  version="1.3.7"
   name="Joystick Support"
   provider-name="Team-Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/peripheral.joystick/resources/settings.xml.include
+++ b/peripheral.joystick/resources/settings.xml.include
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<settings>
-	<category label="30000">
-		@LINUX_SELECT@
-		@SDL_SELECT@
-		@OSX_SELECT@
-		@XINPUT_CHECK@
-		@DIRECTINPUT_CHECK@
-	</category>
+<settings version="1">
+  <section id="addon" label="-1">
+    <category id="main" label="30000">
+      <group id="1" label="-1">
+@LINUX_SELECT@
+@SDL_SELECT@
+@OSX_SELECT@
+@XINPUT_CHECK@
+@DIRECTINPUT_CHECK@
+      </group>
+    </category>
+  </section>
 </settings>

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -83,9 +83,7 @@ void CSettings::SetSetting(const std::string& strName, const void* value)
       };
     }
 
-    const char* strValue = static_cast<const char*>(value);
-    int ifaceIndex = strValue[0] - '0';
-
+    int ifaceIndex = *static_cast<const int*>(value);
     unsigned int driverIndex = 0;
     for (auto driver : drivers)
     {


### PR DESCRIPTION
This fix the addon who comes with latest changes of Kodi to rework addons settings.
Further brings it the new settings.xml style (here my output):
```xml
<?xml version="1.0" encoding="utf-8" standalone="yes"?>
<settings version="1">
  <section id="addon" label="-1">
    <category id="main" label="30000">
      <group id="1" label="0">
        <setting id="driver_linux" type="integer" label="30001">
          <default>0</default>
          <constraints>
            <options>
              <option label="30005">0</option>
              <option label="30007">1</option>
              <option label="30002">2</option>
            </options>
          </constraints>
          <control type="spinner" format="string"/>
        </setting>




      </group>
    </category>
  </section>
</settings>
```