### PR TITLE
[fix] windows build failures

### DIFF
--- a/src/api/directinput/JoystickDirectInput.cpp
+++ b/src/api/directinput/JoystickDirectInput.cpp
@@ -38,7 +38,7 @@ using namespace JOYSTICK;
 
 CJoystickDirectInput::CJoystickDirectInput(GUID                           deviceGuid,
                                            LPDIRECTINPUTDEVICE8           joystickDevice,
-                                           const _TCHAR                   *strName)
+                                           const TCHAR                    *strName)
  : CJoystick(EJoystickInterface::DIRECTINPUT),
    m_deviceGuid(deviceGuid),
    m_joystickDevice(joystickDevice)

--- a/src/api/directinput/JoystickDirectInput.h
+++ b/src/api/directinput/JoystickDirectInput.h
@@ -33,7 +33,7 @@ namespace JOYSTICK
   public:
     CJoystickDirectInput(GUID                           deviceGuid,
                          LPDIRECTINPUTDEVICE8           joystickDevice,
-                         const _TCHAR                   *strName);
+                         const TCHAR                    *strName);
 
     virtual ~CJoystickDirectInput(void);
 

--- a/src/api/directinput/JoystickInterfaceDirectInput.cpp
+++ b/src/api/directinput/JoystickInterfaceDirectInput.cpp
@@ -144,7 +144,7 @@ BOOL CALLBACK CJoystickInterfaceDirectInput::EnumJoysticksCallback(const DIDEVIC
     return DIENUM_CONTINUE;
   }
 
-  const _TCHAR *strName = pdidInstance->tszProductName ? pdidInstance->tszProductName : _TEXT("");
+  const TCHAR *strName = pdidInstance->tszProductName ? pdidInstance->tszProductName : TEXT("");
 
   context->AddScanResult(JoystickPtr(new CJoystickDirectInput(pdidInstance->guidInstance, pJoystick, strName)));
 

--- a/src/api/directinput/JoystickInterfaceDirectInput.cpp
+++ b/src/api/directinput/JoystickInterfaceDirectInput.cpp
@@ -26,7 +26,7 @@
 #include "log/Log.h"
 #include "utils/CommonMacros.h"
 
-#include <kodi/peripheral/libKODI_peripheral.h>
+#include <kodi/addon-instance/Peripheral.h>
 
 #pragma comment(lib, "Dinput8.lib")
 #pragma comment(lib, "dxguid.lib")

--- a/src/api/xinput/JoystickInterfaceXInput.cpp
+++ b/src/api/xinput/JoystickInterfaceXInput.cpp
@@ -34,12 +34,12 @@ using namespace JOYSTICK;
 
 ButtonMap CJoystickInterfaceXInput::m_buttonMap = {
     std::make_pair("game.controller.default", FeatureVector{
-        ADDON::JoystickFeature("leftmotor", JOYSTICK_FEATURE_TYPE_MOTOR),
-        ADDON::JoystickFeature("rightmotor", JOYSTICK_FEATURE_TYPE_MOTOR),
+        kodi::addon::JoystickFeature("leftmotor", JOYSTICK_FEATURE_TYPE_MOTOR),
+        kodi::addon::JoystickFeature("rightmotor", JOYSTICK_FEATURE_TYPE_MOTOR),
     }),
     std::make_pair("game.controller.ps", FeatureVector{
-        ADDON::JoystickFeature("strongmotor", JOYSTICK_FEATURE_TYPE_MOTOR),
-        ADDON::JoystickFeature("weakmotor", JOYSTICK_FEATURE_TYPE_MOTOR),
+        kodi::addon::JoystickFeature("strongmotor", JOYSTICK_FEATURE_TYPE_MOTOR),
+        kodi::addon::JoystickFeature("weakmotor", JOYSTICK_FEATURE_TYPE_MOTOR),
     }),
 };
 
@@ -91,12 +91,12 @@ bool CJoystickInterfaceXInput::ScanForJoysticks(JoystickVector& joysticks)
 const ButtonMap& CJoystickInterfaceXInput::GetButtonMap()
 {
   auto& dflt = m_buttonMap["game.controller.default"];
-  dflt[CJoystickXInput::MOTOR_LEFT].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, ADDON::DriverPrimitive::CreateMotor(CJoystickXInput::MOTOR_LEFT));
-  dflt[CJoystickXInput::MOTOR_RIGHT].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, ADDON::DriverPrimitive::CreateMotor(CJoystickXInput::MOTOR_RIGHT));
+  dflt[CJoystickXInput::MOTOR_LEFT].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, kodi::addon::DriverPrimitive::CreateMotor(CJoystickXInput::MOTOR_LEFT));
+  dflt[CJoystickXInput::MOTOR_RIGHT].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, kodi::addon::DriverPrimitive::CreateMotor(CJoystickXInput::MOTOR_RIGHT));
 
   auto& ps = m_buttonMap["game.controller.ps"];
-  ps[CJoystickXInput::MOTOR_LEFT].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, ADDON::DriverPrimitive::CreateMotor(CJoystickXInput::MOTOR_LEFT));
-  ps[CJoystickXInput::MOTOR_RIGHT].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, ADDON::DriverPrimitive::CreateMotor(CJoystickXInput::MOTOR_RIGHT));
+  ps[CJoystickXInput::MOTOR_LEFT].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, kodi::addon::DriverPrimitive::CreateMotor(CJoystickXInput::MOTOR_LEFT));
+  ps[CJoystickXInput::MOTOR_RIGHT].SetPrimitive(JOYSTICK_MOTOR_PRIMITIVE, kodi::addon::DriverPrimitive::CreateMotor(CJoystickXInput::MOTOR_RIGHT));
 
   return m_buttonMap;
 }

--- a/src/api/xinput/XInputDLL.cpp
+++ b/src/api/xinput/XInputDLL.cpp
@@ -47,16 +47,16 @@ bool CXInputDLL::Load(void)
 
   m_strVersion = "1.4";
   dsyslog("Attempting to load XInput1_4.dll...");
-  m_dll = LoadLibrary(_TEXT("XInput1_4.dll"));  // 1.4 Ships with Windows 8
+  m_dll = LoadLibrary(TEXT("XInput1_4.dll"));  // 1.4 Ships with Windows 8
   if (!m_dll)
   {
     m_strVersion = "1.3";
     dsyslog("Attempting to load XInput1_3.dll...");
-    m_dll = LoadLibrary(_TEXT("XInput1_3.dll"));  // 1.3 Ships with Vista and Win7, can be installed as a redistributable component
+    m_dll = LoadLibrary(TEXT("XInput1_3.dll"));  // 1.3 Ships with Vista and Win7, can be installed as a redistributable component
     if (!m_dll)
     {
       dsyslog("Attempting to load bin\\XInput1_3.dll...");
-      m_dll = LoadLibrary(_TEXT("bin\\XInput1_3.dll"));
+      m_dll = LoadLibrary(TEXT("bin\\XInput1_3.dll"));
     }
   }
 


### PR DESCRIPTION
- TCHAR & TEXT identifiers don't start with an underscore
- updated to C++ based addon interface for window

@garbear @AlwinEsch FYI