### PR TITLE
[cmake] Add missing header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,8 @@ set(JOYSTICK_SOURCES src/addon.cpp
                      src/storage/xml/JoystickFamiliesXml.cpp
                      src/utils/StringUtils.cpp)
 
-set(JOYSTICK_HEADERS src/api/IJoystickInterface.h
+set(JOYSTICK_HEADERS src/addon.h
+                     src/api/IJoystickInterface.h
                      src/api/Joystick.h
                      src/api/JoystickInterfaceCallback.h
                      src/api/JoystickManager.h


### PR DESCRIPTION
This adds the header added in #112 to CMakeLists.txt.