### PR TITLE
Added new buttonmap for PS4 controller (both v1 and v2)

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" ?>
 <buttonmap>
     <device name="Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
-        <configuration>
-            <axis index="2" center="-1" range="1" />
-            <axis index="5" center="-1" range="1" />
-        </configuration>
+        <configuration />
         <controller id="game.controller.default">
             <feature name="a" button="0" />
             <feature name="b" button="1" />

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" ?>
 <buttonmap>
     <device name="Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
-        <configuration />
+        <configuration>
+            <axis index="2" center="-1" range="1" />
+            <axis index="5" center="-1" range="1" />
+        </configuration>
         <controller id="game.controller.default">
             <feature name="a" button="0" />
             <feature name="b" button="1" />
@@ -32,6 +35,127 @@
             <feature name="up" axis="-7" />
             <feature name="x" button="3" />
             <feature name="y" button="2" />
+        </controller>
+        <controller id="game.controller.dreamcast">
+            <feature name="a" button="0" />
+            <feature name="analogstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="b" button="1" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="lefttrigger" button="6" />
+            <feature name="right" axis="+6" />
+            <feature name="righttrigger" button="7" />
+            <feature name="start" button="10" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="3" />
+            <feature name="y" button="2" />
+        </controller>
+        <controller id="game.controller.gba">
+            <feature name="a" button="1" />
+            <feature name="b" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="8" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+        </controller>
+        <controller id="game.controller.genesis">
+            <feature name="a" button="3" />
+            <feature name="b" button="0" />
+            <feature name="c" button="1" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="mode" button="8" />
+            <feature name="right" axis="+6" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="4" />
+            <feature name="z" button="5" />
+        </controller>
+        <controller id="game.controller.n64">
+            <feature name="a" button="0" />
+            <feature name="analogstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="b" button="3" />
+            <feature name="cdown" axis="+4" />
+            <feature name="cleft" axis="-3" />
+            <feature name="cright" axis="+3" />
+            <feature name="cup" axis="-4" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="start" button="10" />
+            <feature name="up" axis="-7" />
+            <feature name="z" button="12" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="0" />
+            <feature name="b" button="3" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="right" axis="+6" />
+            <feature name="select" button="8" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+        </controller>
+        <controller id="game.controller.ps">
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="11" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" button="6" />
+            <feature name="r3" button="12" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" button="7" />
+            <feature name="select" button="8" />
+            <feature name="square" button="3" />
+            <feature name="start" button="9" />
+            <feature name="triangle" button="2" />
+            <feature name="up" axis="-7" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="1" />
+            <feature name="b" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="8" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
+        <configuration />
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="8" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="10" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="11" />
+            <feature name="lefttrigger" button="6" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="12" />
+            <feature name="righttrigger" button="7" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="3" />
+            <feature name="y" button="2" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
After updating my system, it seems like the PS4 (both v1 and v2) controllers are detected a bit differently. I created a new buttonmap for it, which I'm providing in this PR. It seems like both v1 and v2 are detected as the same type of controller now, so only 1 buttonmap is required.

I think this may be because I updated to the linux 4.11 kernel which now has support for the PS4v2 controller. In earlier kernel versions, the PS4v2 controller wasn't explicitly supported, it seemed to partially work because of the PS4v1 controller code.