### PR TITLE
[Peripheral API] Update to v1.3.4: relative pointer support

### DIFF
--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.4.1"
+  version="1.4.2"
   name="Joystick Support"
   provider-name="Team-Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/buttonmapper/ButtonMapUtils.cpp
+++ b/src/buttonmapper/ButtonMapUtils.cpp
@@ -42,6 +42,7 @@ bool ButtonMapUtils::PrimitivesEqual(const kodi::addon::JoystickFeature& lhs, co
       return lhs.Primitive(JOYSTICK_SCALAR_PRIMITIVE) == rhs.Primitive(JOYSTICK_SCALAR_PRIMITIVE);
     }
     case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
+    case JOYSTICK_FEATURE_TYPE_RELPOINTER:
     {
       return lhs.Primitive(JOYSTICK_ANALOG_STICK_UP)    == rhs.Primitive(JOYSTICK_ANALOG_STICK_UP) &&
              lhs.Primitive(JOYSTICK_ANALOG_STICK_DOWN)  == rhs.Primitive(JOYSTICK_ANALOG_STICK_DOWN) &&
@@ -135,7 +136,15 @@ const std::vector<JOYSTICK_FEATURE_PRIMITIVE>& ButtonMapUtils::GetPrimitives(JOY
       JOYSTICK_FEATURE_TYPE_MOTOR, {
         JOYSTICK_MOTOR_PRIMITIVE,
       }
-    }
+    },
+    {
+      JOYSTICK_FEATURE_TYPE_RELPOINTER, {
+        JOYSTICK_ANALOG_STICK_UP,
+        JOYSTICK_ANALOG_STICK_DOWN,
+        JOYSTICK_ANALOG_STICK_RIGHT,
+        JOYSTICK_ANALOG_STICK_LEFT,
+      }
+    },
   };
 
   auto itPair = m_primitiveMap.find(featureType);

--- a/src/storage/ButtonMap.cpp
+++ b/src/storage/ButtonMap.cpp
@@ -35,19 +35,21 @@ using namespace JOYSTICK;
 
 #define RESOURCE_LIFETIME_MS  2000 // 2 seconds
 
-CButtonMap::CButtonMap(const std::string& strResourcePath) :
+CButtonMap::CButtonMap(const std::string& strResourcePath, IControllerHelper *controllerHelper) :
   m_strResourcePath(strResourcePath),
   m_device(std::move(std::make_shared<CDevice>())),
   m_timestamp(-1),
-  m_bModified(false)
+  m_bModified(false),
+  m_controllerHelper(controllerHelper)
 {
 }
 
-CButtonMap::CButtonMap(const std::string& strResourcePath, const DevicePtr& device) :
+CButtonMap::CButtonMap(const std::string& strResourcePath, const DevicePtr& device, IControllerHelper *controllerHelper) :
   m_strResourcePath(strResourcePath),
   m_device(device),
   m_timestamp(-1),
-  m_bModified(false)
+  m_bModified(false),
+  m_controllerHelper(controllerHelper)
 {
 }
 

--- a/src/storage/ButtonMap.h
+++ b/src/storage/ButtonMap.h
@@ -28,11 +28,13 @@
 
 namespace JOYSTICK
 {
+  class IControllerHelper;
+
   class CButtonMap
   {
   public:
-    CButtonMap(const std::string& strResourcePath);
-    CButtonMap(const std::string& strResourcePath, const DevicePtr& device);
+    CButtonMap(const std::string& strResourcePath, IControllerHelper *controllerHelper);
+    CButtonMap(const std::string& strResourcePath, const DevicePtr& device, IControllerHelper *controllerHelper);
 
     virtual ~CButtonMap(void) { }
 
@@ -61,6 +63,9 @@ namespace JOYSTICK
     static void MergeFeature(const kodi::addon::JoystickFeature& feature, FeatureVector& features, const std::string& controllerId);
 
     static void Sanitize(FeatureVector& features, const std::string& controllerId);
+
+    // Construction parameter
+    IControllerHelper *const m_controllerHelper;
 
     const std::string m_strResourcePath;
     DevicePtr         m_device;

--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -86,9 +86,9 @@ bool CStorageManager::Initialize(CPeripheralJoystick* peripheralLib)
   // Ensure button map path exists in user data
   CStorageUtils::EnsureDirectoryExists(strUserButtonMapPath);
 
-  m_databases.push_back(DatabasePtr(new CDatabaseXml(strUserButtonMapPath, true, m_buttonMapper->GetCallbacks())));
+  m_databases.push_back(DatabasePtr(new CDatabaseXml(strUserButtonMapPath, true, m_buttonMapper->GetCallbacks(), this)));
   //m_databases.push_back(DatabasePtr(new CDatabaseRetroArch(strUserButtonMapPath, true, &m_controllerMapper))); // TODO
-  m_databases.push_back(DatabasePtr(new CDatabaseXml(strAddonButtonMapPath, false, m_buttonMapper->GetCallbacks())));
+  m_databases.push_back(DatabasePtr(new CDatabaseXml(strAddonButtonMapPath, false, m_buttonMapper->GetCallbacks(), this)));
   //m_databases.push_back(DatabasePtr(new CDatabaseRetroArch(strAddonButtonMapPath, false))); // TODO
 
   m_databases.push_back(DatabasePtr(new CDatabaseJoystickAPI(m_buttonMapper->GetCallbacks())));
@@ -183,4 +183,12 @@ void CStorageManager::RefreshButtonMaps(const std::string& strDeviceName /* = ""
   // Request the frontend to refresh its button maps
   if (m_peripheralLib)
     m_peripheralLib->RefreshButtonMaps(strDeviceName);
+}
+
+JOYSTICK_FEATURE_TYPE CStorageManager::FeatureType(const std::string& strControllerId, const std::string &featureName)
+{
+  if (m_peripheralLib)
+    return m_peripheralLib->FeatureType(strControllerId, featureName);
+
+  return JOYSTICK_FEATURE_TYPE_UNKNOWN;
 }

--- a/src/storage/StorageManager.h
+++ b/src/storage/StorageManager.h
@@ -39,11 +39,30 @@ namespace addon
 
 namespace JOYSTICK
 {
+  /*!
+   * \brief Helper functions for dealing with controllers and controller features
+   */
+  class IControllerHelper
+  {
+  public:
+    virtual ~IControllerHelper() = default;
+
+    /*!
+     * \brief Return the type of the specified feature
+     *
+     * \param controllerId    The controller ID to check
+     * \param featureName     The feature to check
+     *
+     * \return The type of the feature, or JOYSTICK_FEATURE_TYPE_UNKNOWN if unknown
+     */
+    virtual JOYSTICK_FEATURE_TYPE FeatureType(const std::string& strControllerId, const std::string &featureName) = 0;
+  };
+
   class CButtonMapper;
   class CDevice;
   class IDatabase;
 
-  class CStorageManager
+  class CStorageManager : public IControllerHelper
   {
   private:
     CStorageManager(void);
@@ -148,6 +167,9 @@ namespace JOYSTICK
      * \param[optional] controllerId The controller ID to refresh, or empty for all controllers
      */
     void RefreshButtonMaps(const std::string& strDeviceName = "");
+
+    // implementation of IControllerHelper
+    virtual JOYSTICK_FEATURE_TYPE FeatureType(const std::string& strControllerId, const std::string &featureName) override;
 
   private:
     CPeripheralJoystick* m_peripheralLib;

--- a/src/storage/xml/ButtonMapXml.h
+++ b/src/storage/xml/ButtonMapXml.h
@@ -38,12 +38,13 @@ namespace JOYSTICK
 {
   class CAnomalousTrigger;
   class CButtonMap;
+  class IControllerHelper;
 
   class CButtonMapXml : public CButtonMap
   {
   public:
-    CButtonMapXml(const std::string& strResourcePath);
-    CButtonMapXml(const std::string& strResourcePath, const DevicePtr& device);
+    CButtonMapXml(const std::string& strResourcePath, IControllerHelper *controllerHelper);
+    CButtonMapXml(const std::string& strResourcePath, const DevicePtr& device, IControllerHelper *controllerHelper);
 
     virtual ~CButtonMapXml(void) { }
 
@@ -55,8 +56,8 @@ namespace JOYSTICK
   private:
     bool SerializeButtonMaps(TiXmlElement* pElement) const;
 
-    static bool Serialize(const FeatureVector& features, TiXmlElement* pElement);
-    static bool Deserialize(const TiXmlElement* pElement, FeatureVector& features);
+    bool Serialize(const FeatureVector& features, TiXmlElement* pElement) const;
+    bool Deserialize(const TiXmlElement* pElement, FeatureVector& features, const std::string &controllerId) const;
 
     static bool IsValid(const kodi::addon::JoystickFeature& feature);
     static bool SerializeFeature(TiXmlElement* pElement, const kodi::addon::DriverPrimitive& primitive, const char* tagName);

--- a/src/storage/xml/DatabaseXml.cpp
+++ b/src/storage/xml/DatabaseXml.cpp
@@ -24,17 +24,18 @@
 
 using namespace JOYSTICK;
 
-CDatabaseXml::CDatabaseXml(const std::string& strBasePath, bool bReadWrite, IDatabaseCallbacks* callbacks) :
-  CJustABunchOfFiles(strBasePath + "/" RESOURCE_XML_FOLDER, RESOURCE_XML_EXTENSION, bReadWrite, callbacks)
+CDatabaseXml::CDatabaseXml(const std::string& strBasePath, bool bReadWrite, IDatabaseCallbacks* callbacks, IControllerHelper *controllerHelper) :
+  CJustABunchOfFiles(strBasePath + "/" RESOURCE_XML_FOLDER, RESOURCE_XML_EXTENSION, bReadWrite, callbacks),
+  m_controllerHelper(controllerHelper)
 {
 }
 
 CButtonMap* CDatabaseXml::CreateResource(const std::string& resourcePath) const
 {
-  return new CButtonMapXml(resourcePath);
+  return new CButtonMapXml(resourcePath, m_controllerHelper);
 }
 
 CButtonMap* CDatabaseXml::CreateResource(const std::string& resourcePath, const DevicePtr& deviceInfo) const
 {
-  return new CButtonMapXml(resourcePath, deviceInfo);
+  return new CButtonMapXml(resourcePath, deviceInfo, m_controllerHelper);
 }

--- a/src/storage/xml/DatabaseXml.h
+++ b/src/storage/xml/DatabaseXml.h
@@ -28,15 +28,21 @@ class TiXmlElement;
 
 namespace JOYSTICK
 {
+  class IControllerHelper;
+
   class CDatabaseXml : public CJustABunchOfFiles
   {
   public:
-    CDatabaseXml(const std::string& strBasePath, bool bReadWrite, IDatabaseCallbacks* callbacks);
+    CDatabaseXml(const std::string& strBasePath, bool bReadWrite, IDatabaseCallbacks* callbacks, IControllerHelper *controllerHelper);
 
     virtual ~CDatabaseXml(void) { }
 
     // implementation of CJustABunchOfFiles
     virtual CButtonMap* CreateResource(const std::string& resourcePath) const override;
     virtual CButtonMap* CreateResource(const std::string& resourcePath, const DevicePtr& deviceInfo) const override;
+
+  private:
+    // Construction parameter
+    IControllerHelper *const m_controllerHelper;
   };
 }


### PR DESCRIPTION
This updates peripheral.joystick to handle serializing/deserializing relative pointers. Corresponds to https://github.com/xbmc/xbmc/pull/12556.