### PR TITLE
Bump version to v1.4.3 to anchor backport of buttonmaps

### DIFF
--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.4.2"
+  version="1.4.3"
   name="Joystick Support"
   provider-name="Team-Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This bumps the version to v1.4.3 so that the backported buttonmaps in https://github.com/xbmc/peripheral.joystick/pull/131 have an up-to-date version to reference.