### PR TITLE
[Peripheral API] Update to v1.3.5: Wheel and throttle support

### DIFF
--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.4.3"
+  version="1.4.4"
   name="Joystick Support"
   provider-name="Team-Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/buttonmapper/ButtonMapUtils.cpp
+++ b/src/buttonmapper/ButtonMapUtils.cpp
@@ -55,6 +55,16 @@ bool ButtonMapUtils::PrimitivesEqual(const kodi::addon::JoystickFeature& lhs, co
              lhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y) == rhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y) &&
              lhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z) == rhs.Primitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z);
     }
+    case JOYSTICK_FEATURE_TYPE_WHEEL:
+    {
+      return lhs.Primitive(JOYSTICK_WHEEL_RIGHT) == rhs.Primitive(JOYSTICK_WHEEL_RIGHT) &&
+             lhs.Primitive(JOYSTICK_WHEEL_LEFT)  == rhs.Primitive(JOYSTICK_WHEEL_LEFT);
+    }
+    case JOYSTICK_FEATURE_TYPE_THROTTLE:
+    {
+      return lhs.Primitive(JOYSTICK_THROTTLE_UP)    == rhs.Primitive(JOYSTICK_THROTTLE_UP) &&
+             lhs.Primitive(JOYSTICK_THROTTLE_DOWN)  == rhs.Primitive(JOYSTICK_THROTTLE_DOWN);
+    }
     default:
       break;
     }
@@ -143,6 +153,18 @@ const std::vector<JOYSTICK_FEATURE_PRIMITIVE>& ButtonMapUtils::GetPrimitives(JOY
         JOYSTICK_ANALOG_STICK_DOWN,
         JOYSTICK_ANALOG_STICK_RIGHT,
         JOYSTICK_ANALOG_STICK_LEFT,
+      }
+    },
+    {
+      JOYSTICK_FEATURE_TYPE_WHEEL, {
+        JOYSTICK_WHEEL_RIGHT,
+        JOYSTICK_WHEEL_LEFT,
+      }
+    },
+    {
+      JOYSTICK_FEATURE_TYPE_THROTTLE, {
+        JOYSTICK_THROTTLE_UP,
+        JOYSTICK_THROTTLE_DOWN,
       }
     },
   };

--- a/src/storage/xml/ButtonMapXml.cpp
+++ b/src/storage/xml/ButtonMapXml.cpp
@@ -246,6 +246,26 @@ bool CButtonMapXml::Serialize(const FeatureVector& features, TiXmlElement* pElem
 
         break;
       }
+      case JOYSTICK_FEATURE_TYPE_WHEEL:
+      {
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_WHEEL_LEFT), BUTTONMAP_XML_ELEM_LEFT))
+          return false;
+
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_WHEEL_RIGHT), BUTTONMAP_XML_ELEM_RIGHT))
+          return false;
+
+        break;
+      }
+      case JOYSTICK_FEATURE_TYPE_THROTTLE:
+      {
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_THROTTLE_UP), BUTTONMAP_XML_ELEM_UP))
+          return false;
+
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_THROTTLE_DOWN), BUTTONMAP_XML_ELEM_DOWN))
+          return false;
+
+        break;
+      }
       default:
         break;
     }
@@ -484,6 +504,60 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
         feature.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_X, positiveX);
         feature.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_Y, positiveY);
         feature.SetPrimitive(JOYSTICK_ACCELEROMETER_POSITIVE_Z, positiveZ);
+
+        break;
+      }
+      case JOYSTICK_FEATURE_TYPE_WHEEL:
+      {
+        kodi::addon::DriverPrimitive right;
+        kodi::addon::DriverPrimitive left;
+
+        bool bSuccess = true;
+
+        if (pRight && !DeserializePrimitive(pRight, right, strName))
+        {
+          esyslog("Feature \"%s\": <%s> tag is not a valid primitive", strName.c_str(), BUTTONMAP_XML_ELEM_RIGHT);
+          bSuccess = false;
+        }
+
+        if (pLeft && !DeserializePrimitive(pLeft, left, strName))
+        {
+          esyslog("Feature \"%s\": <%s> tag is not a valid primitive", strName.c_str(), BUTTONMAP_XML_ELEM_LEFT);
+          bSuccess = false;
+        }
+
+        if (!bSuccess)
+          return false;
+
+        feature.SetPrimitive(JOYSTICK_WHEEL_RIGHT, right);
+        feature.SetPrimitive(JOYSTICK_WHEEL_LEFT, left);
+
+        break;
+      }
+      case JOYSTICK_FEATURE_TYPE_THROTTLE:
+      {
+        kodi::addon::DriverPrimitive up;
+        kodi::addon::DriverPrimitive down;
+
+        bool bSuccess = true;
+
+        if (pUp && !DeserializePrimitive(pUp, up, strName))
+        {
+          esyslog("Feature \"%s\": <%s> tag is not a valid primitive", strName.c_str(), BUTTONMAP_XML_ELEM_UP);
+          bSuccess = false;
+        }
+
+        if (pDown && !DeserializePrimitive(pDown, down, strName))
+        {
+          esyslog("Feature \"%s\": <%s> tag is not a valid primitive", strName.c_str(), BUTTONMAP_XML_ELEM_DOWN);
+          bSuccess = false;
+        }
+
+        if (!bSuccess)
+          return false;
+
+        feature.SetPrimitive(JOYSTICK_THROTTLE_UP, up);
+        feature.SetPrimitive(JOYSTICK_THROTTLE_DOWN, down);
 
         break;
       }


### PR DESCRIPTION
This PR allows wheels and throttles to be mapped in the button mapper.

The buttonmap XML for wheels looks like:

```xml
<controller id="game.controller.saturn.arcade.racer">
    <feature name="wheel">
        <left axis="-0" />
        <right axis="+0" />
    </feature>
</controller>
```

The buttonmap XML for throttles looks like:

```xml
<controller id="game.controller.saturn.mission.stick">
    <feature name="throttle">
        <up axis="+3" />
        <down axis="-3" />
    </feature>
</controller>
```
        
For https://github.com/xbmc/xbmc/pull/13189.