### PR TITLE
Peripheral API v1.3.7: Mouse mapping support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(JOYSTICK_SOURCES src/addon.cpp
                      src/storage/Device.cpp
                      src/storage/DeviceConfiguration.cpp
                      src/storage/JustABunchOfFiles.cpp
+                     src/storage/MouseTranslator.cpp
                      src/storage/StorageManager.cpp
                      src/storage/StorageUtils.cpp
                      src/storage/api/DatabaseJoystickAPI.cpp
@@ -95,6 +96,7 @@ set(JOYSTICK_HEADERS src/addon.h
                      src/storage/Device.h
                      src/storage/IDatabase.h
                      src/storage/JustABunchOfFiles.h
+                     src/storage/MouseTranslator.h
                      src/storage/PrimitiveConfiguration.h
                      src/storage/StorageDefinitions.h
                      src/storage/StorageManager.h

--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.4.5"
+  version="1.4.6"
   name="Joystick Support"
   provider-name="Team-Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/peripheral.joystick/resources/buttonmaps/xml/application/Mouse.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/application/Mouse.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Mouse" provider="application">
+        <controller id="game.controller.mouse">
+            <feature name="button4" mouse="button4" />
+            <feature name="button5" mouse="button5" />
+            <feature name="horizwheelleft" mouse="horizwheelleft" />
+            <feature name="horizwheelright" mouse="horizwheelright" />
+            <feature name="left" mouse="left" />
+            <feature name="middle" mouse="middle" />
+            <feature name="pointer">
+                <up axis="-y" />
+                <down axis="+y" />
+                <right axis="+x" />
+                <left axis="-x" />
+            </feature>
+            <feature name="right" mouse="right" />
+            <feature name="wheeldown" mouse="wheeldown" />
+            <feature name="wheelup" mouse="wheelup" />
+        </controller>
+    </device>
+</buttonmap>

--- a/src/api/JoystickTranslator.cpp
+++ b/src/api/JoystickTranslator.cpp
@@ -158,3 +158,29 @@ const char* JoystickTranslator::TranslateSemiAxisDir(JOYSTICK_DRIVER_SEMIAXIS_DI
   }
   return "";
 }
+
+
+JOYSTICK_DRIVER_RELPOINTER_DIRECTION JoystickTranslator::TranslateRelPointerDir(const std::string relPointerDir)
+{
+  if (relPointerDir == "+x") return JOYSTICK_DRIVER_RELPOINTER_RIGHT;
+  if (relPointerDir == "-x") return JOYSTICK_DRIVER_RELPOINTER_LEFT;
+  if (relPointerDir == "+y") return JOYSTICK_DRIVER_RELPOINTER_UP;
+  if (relPointerDir == "-y") return JOYSTICK_DRIVER_RELPOINTER_DOWN;
+
+  return JOYSTICK_DRIVER_RELPOINTER_UNKNOWN;
+}
+
+const char* JoystickTranslator::TranslateRelPointerDir(JOYSTICK_DRIVER_RELPOINTER_DIRECTION dir)
+{
+  switch (dir)
+  {
+  case JOYSTICK_DRIVER_RELPOINTER_RIGHT: return "+x";
+  case JOYSTICK_DRIVER_RELPOINTER_LEFT:  return "-x";
+  case JOYSTICK_DRIVER_RELPOINTER_UP:    return "+y";
+  case JOYSTICK_DRIVER_RELPOINTER_DOWN:  return "-y";
+  default:
+    break;
+  }
+
+  return "";
+}

--- a/src/api/JoystickTranslator.cpp
+++ b/src/api/JoystickTranslator.cpp
@@ -164,8 +164,8 @@ JOYSTICK_DRIVER_RELPOINTER_DIRECTION JoystickTranslator::TranslateRelPointerDir(
 {
   if (relPointerDir == "+x") return JOYSTICK_DRIVER_RELPOINTER_RIGHT;
   if (relPointerDir == "-x") return JOYSTICK_DRIVER_RELPOINTER_LEFT;
-  if (relPointerDir == "+y") return JOYSTICK_DRIVER_RELPOINTER_UP;
-  if (relPointerDir == "-y") return JOYSTICK_DRIVER_RELPOINTER_DOWN;
+  if (relPointerDir == "-y") return JOYSTICK_DRIVER_RELPOINTER_UP;
+  if (relPointerDir == "+y") return JOYSTICK_DRIVER_RELPOINTER_DOWN;
 
   return JOYSTICK_DRIVER_RELPOINTER_UNKNOWN;
 }
@@ -176,8 +176,8 @@ const char* JoystickTranslator::TranslateRelPointerDir(JOYSTICK_DRIVER_RELPOINTE
   {
   case JOYSTICK_DRIVER_RELPOINTER_RIGHT: return "+x";
   case JOYSTICK_DRIVER_RELPOINTER_LEFT:  return "-x";
-  case JOYSTICK_DRIVER_RELPOINTER_UP:    return "+y";
-  case JOYSTICK_DRIVER_RELPOINTER_DOWN:  return "-y";
+  case JOYSTICK_DRIVER_RELPOINTER_UP:    return "-y";
+  case JOYSTICK_DRIVER_RELPOINTER_DOWN:  return "+y";
   default:
     break;
   }

--- a/src/api/JoystickTranslator.h
+++ b/src/api/JoystickTranslator.h
@@ -38,5 +38,8 @@ namespace JOYSTICK
 
     static JOYSTICK_DRIVER_SEMIAXIS_DIRECTION TranslateSemiAxisDir(char axisSign);
     static const char* TranslateSemiAxisDir(JOYSTICK_DRIVER_SEMIAXIS_DIRECTION dir);
+
+    static JOYSTICK_DRIVER_RELPOINTER_DIRECTION TranslateRelPointerDir(const std::string relPointerDir);
+    static const char* TranslateRelPointerDir(JOYSTICK_DRIVER_RELPOINTER_DIRECTION dir);
   };
 }

--- a/src/buttonmapper/ButtonMapTranslator.cpp
+++ b/src/buttonmapper/ButtonMapTranslator.cpp
@@ -20,6 +20,7 @@
 
 #include "ButtonMapTranslator.h"
 #include "api/JoystickTranslator.h"
+#include "storage/MouseTranslator.h"
 
 #include <cstdlib>
 #include <cctype>
@@ -63,6 +64,16 @@ std::string ButtonMapTranslator::ToString(const kodi::addon::DriverPrimitive& pr
       strPrimitive << primitive.Keycode();
       break;
     }
+    case JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOUSE_BUTTON:
+    {
+      strPrimitive << CMouseTranslator::SerializeMouseButton(primitive.MouseIndex());
+      break;
+    }
+    case JOYSTICK_DRIVER_PRIMITIVE_TYPE_RELPOINTER_DIRECTION:
+    {
+      strPrimitive << JoystickTranslator::TranslateRelPointerDir(primitive.RelPointerDirection());
+      break;
+    }
     default:
       break;
   }
@@ -98,11 +109,22 @@ kodi::addon::DriverPrimitive ButtonMapTranslator::ToDriverPrimitive(const std::s
       }
       break;
     }
+    case JOYSTICK_DRIVER_PRIMITIVE_TYPE_RELPOINTER_DIRECTION:
     case JOYSTICK_DRIVER_PRIMITIVE_TYPE_SEMIAXIS:
     {
-      JOYSTICK_DRIVER_SEMIAXIS_DIRECTION dir = JoystickTranslator::TranslateSemiAxisDir(strPrimitive[0]);
-      if (dir != JOYSTICK_DRIVER_SEMIAXIS_UNKNOWN)
-        primitive = kodi::addon::DriverPrimitive(std::atoi(strPrimitive.substr(1).c_str()), 0, dir, 1);
+      // First try to deserialize relative pointer axis
+      JOYSTICK_DRIVER_RELPOINTER_DIRECTION dir = JoystickTranslator::TranslateRelPointerDir(strPrimitive);
+      if (dir != JOYSTICK_DRIVER_RELPOINTER_UNKNOWN)
+      {
+        primitive = kodi::addon::DriverPrimitive(dir);
+      }
+      else
+      {
+        // Next try to deserialize semiaxis
+        JOYSTICK_DRIVER_SEMIAXIS_DIRECTION dir = JoystickTranslator::TranslateSemiAxisDir(strPrimitive[0]);
+        if (dir != JOYSTICK_DRIVER_SEMIAXIS_UNKNOWN)
+          primitive = kodi::addon::DriverPrimitive(std::atoi(strPrimitive.substr(1).c_str()), 0, dir, 1);
+      }
       break;
     }
     case JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOTOR:
@@ -114,6 +136,11 @@ kodi::addon::DriverPrimitive ButtonMapTranslator::ToDriverPrimitive(const std::s
     case JOYSTICK_DRIVER_PRIMITIVE_TYPE_KEY:
     {
       primitive = kodi::addon::DriverPrimitive(strPrimitive);
+      break;
+    }
+    case JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOUSE_BUTTON:
+    {
+      primitive = kodi::addon::DriverPrimitive::CreateMouseButton(CMouseTranslator::DeserializeMouseButton(strPrimitive));
       break;
     }
     default:

--- a/src/buttonmapper/ButtonMapUtils.cpp
+++ b/src/buttonmapper/ButtonMapUtils.cpp
@@ -93,6 +93,18 @@ bool ButtonMapUtils::PrimitivesConflict(const kodi::addon::DriverPrimitive& lhs,
         return true;
       break;
     }
+    case JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOUSE_BUTTON:
+    {
+      if (lhs.MouseIndex() == rhs.MouseIndex())
+        return true;
+      break;
+    }
+    case JOYSTICK_DRIVER_PRIMITIVE_TYPE_RELPOINTER_DIRECTION:
+    {
+      if (lhs.RelPointerDirection() == rhs.RelPointerDirection())
+        return true;
+      break;
+    }
     default:
       return true;
     }
@@ -146,10 +158,10 @@ const std::vector<JOYSTICK_FEATURE_PRIMITIVE>& ButtonMapUtils::GetPrimitives(JOY
     },
     {
       JOYSTICK_FEATURE_TYPE_RELPOINTER, {
-        JOYSTICK_ANALOG_STICK_UP,
-        JOYSTICK_ANALOG_STICK_DOWN,
-        JOYSTICK_ANALOG_STICK_RIGHT,
-        JOYSTICK_ANALOG_STICK_LEFT,
+        JOYSTICK_RELPOINTER_UP,
+        JOYSTICK_RELPOINTER_DOWN,
+        JOYSTICK_RELPOINTER_RIGHT,
+        JOYSTICK_RELPOINTER_LEFT,
       }
     },
     {

--- a/src/storage/Device.cpp
+++ b/src/storage/Device.cpp
@@ -22,6 +22,16 @@
 
 using namespace JOYSTICK;
 
+namespace JOYSTICK
+{
+  bool AreElementCountsKnown(const kodi::addon::Joystick &joystick)
+  {
+    return joystick.ButtonCount() != 0 ||
+           joystick.HatCount() != 0 ||
+           joystick.AxisCount() != 0;
+  }
+}
+
 CDevice::CDevice(const kodi::addon::Joystick& joystick) :
   kodi::addon::Joystick(joystick)
 {
@@ -94,7 +104,7 @@ bool CDevice::SimilarTo(const CDevice& other) const
     }
   }
 
-  if (AreElementCountsKnown() && other.AreElementCountsKnown())
+  if (AreElementCountsKnown(*this) && AreElementCountsKnown(other))
   {
     if (ButtonCount() != other.ButtonCount() ||
         HatCount() != other.HatCount() ||
@@ -127,7 +137,7 @@ void CDevice::MergeProperties(const CDevice& record)
     SetProductID(record.ProductID());
   }
 
-  if (record.AreElementCountsKnown())
+  if (AreElementCountsKnown(record))
   {
     SetButtonCount(record.ButtonCount());
     SetHatCount(record.HatCount());

--- a/src/storage/MouseTranslator.cpp
+++ b/src/storage/MouseTranslator.cpp
@@ -1,0 +1,68 @@
+/*
+ *      Copyright (C) 2018 Garrett Brown
+ *      Copyright (C) 2018 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MouseTranslator.h"
+
+using namespace JOYSTICK;
+
+#define MOUSE_BUTTON_NAME_LEFT               "left"
+#define MOUSE_BUTTON_NAME_RIGHT              "right"
+#define MOUSE_BUTTON_NAME_MIDDLE             "middle"
+#define MOUSE_BUTTON_NAME_BUTTON4            "button4"
+#define MOUSE_BUTTON_NAME_BUTTON5            "button5"
+#define MOUSE_BUTTON_NAME_WHEEL_UP           "wheelup"
+#define MOUSE_BUTTON_NAME_WHEEL_DOWN         "wheeldown"
+#define MOUSE_BUTTON_NAME_HORIZ_WHEEL_LEFT   "horizwheelleft"
+#define MOUSE_BUTTON_NAME_HORIZ_WHEEL_RIGHT  "horizwheelright"
+
+std::string CMouseTranslator::SerializeMouseButton(JOYSTICK_DRIVER_MOUSE_INDEX buttonIndex)
+{
+  switch (buttonIndex)
+  {
+  case JOYSTICK_DRIVER_MOUSE_INDEX_LEFT:              return MOUSE_BUTTON_NAME_LEFT;
+  case JOYSTICK_DRIVER_MOUSE_INDEX_RIGHT:             return MOUSE_BUTTON_NAME_RIGHT;
+  case JOYSTICK_DRIVER_MOUSE_INDEX_MIDDLE:            return MOUSE_BUTTON_NAME_MIDDLE;
+  case JOYSTICK_DRIVER_MOUSE_INDEX_BUTTON4:           return MOUSE_BUTTON_NAME_BUTTON4;
+  case JOYSTICK_DRIVER_MOUSE_INDEX_BUTTON5:           return MOUSE_BUTTON_NAME_BUTTON5;
+  case JOYSTICK_DRIVER_MOUSE_INDEX_WHEEL_UP:          return MOUSE_BUTTON_NAME_WHEEL_UP;
+  case JOYSTICK_DRIVER_MOUSE_INDEX_WHEEL_DOWN:        return MOUSE_BUTTON_NAME_WHEEL_DOWN;
+  case JOYSTICK_DRIVER_MOUSE_INDEX_HORIZ_WHEEL_LEFT:  return MOUSE_BUTTON_NAME_HORIZ_WHEEL_LEFT;
+  case JOYSTICK_DRIVER_MOUSE_INDEX_HORIZ_WHEEL_RIGHT: return MOUSE_BUTTON_NAME_HORIZ_WHEEL_RIGHT;
+  default:
+    break;
+  }
+
+  return "";
+}
+
+JOYSTICK_DRIVER_MOUSE_INDEX CMouseTranslator::DeserializeMouseButton(const std::string &buttonName)
+{
+  if (buttonName == MOUSE_BUTTON_NAME_LEFT)              return JOYSTICK_DRIVER_MOUSE_INDEX_LEFT;
+  if (buttonName == MOUSE_BUTTON_NAME_RIGHT)             return JOYSTICK_DRIVER_MOUSE_INDEX_RIGHT;
+  if (buttonName == MOUSE_BUTTON_NAME_MIDDLE)            return JOYSTICK_DRIVER_MOUSE_INDEX_MIDDLE;
+  if (buttonName == MOUSE_BUTTON_NAME_BUTTON4)           return JOYSTICK_DRIVER_MOUSE_INDEX_BUTTON4;
+  if (buttonName == MOUSE_BUTTON_NAME_BUTTON5)           return JOYSTICK_DRIVER_MOUSE_INDEX_BUTTON5;
+  if (buttonName == MOUSE_BUTTON_NAME_WHEEL_UP)          return JOYSTICK_DRIVER_MOUSE_INDEX_WHEEL_UP;
+  if (buttonName == MOUSE_BUTTON_NAME_WHEEL_DOWN)        return JOYSTICK_DRIVER_MOUSE_INDEX_WHEEL_DOWN;
+  if (buttonName == MOUSE_BUTTON_NAME_HORIZ_WHEEL_LEFT)  return JOYSTICK_DRIVER_MOUSE_INDEX_HORIZ_WHEEL_LEFT;
+  if (buttonName == MOUSE_BUTTON_NAME_HORIZ_WHEEL_RIGHT) return JOYSTICK_DRIVER_MOUSE_INDEX_HORIZ_WHEEL_RIGHT;
+
+  return JOYSTICK_DRIVER_MOUSE_INDEX_UNKNOWN;
+}

--- a/src/storage/MouseTranslator.h
+++ b/src/storage/MouseTranslator.h
@@ -1,0 +1,37 @@
+/*
+ *      Copyright (C) 2018 Garrett Brown
+ *      Copyright (C) 2018 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <kodi/addon-instance/Peripheral.h>
+
+#include <string>
+
+namespace JOYSTICK
+{
+  /*!
+   * \brief Helper functions for translating mouse IDs
+   */
+  class CMouseTranslator
+  {
+  public:
+    static std::string SerializeMouseButton(JOYSTICK_DRIVER_MOUSE_INDEX buttonIndex);
+    static JOYSTICK_DRIVER_MOUSE_INDEX DeserializeMouseButton(const std::string &buttonName);
+  };
+}

--- a/src/storage/StorageUtils.cpp
+++ b/src/storage/StorageUtils.cpp
@@ -109,13 +109,13 @@ std::string CStorageUtils::PrimitiveToString(const kodi::addon::DriverPrimitive&
     switch (primitive.HatDirection())
     {
     case JOYSTICK_DRIVER_HAT_UP:
-      return StringUtils::Format("hat up");
+      return "hat up";
     case JOYSTICK_DRIVER_HAT_RIGHT:
-      return StringUtils::Format("hat right");
+      return "hat right";
     case JOYSTICK_DRIVER_HAT_DOWN:
-      return StringUtils::Format("hat down");
+      return "hat down";
     case JOYSTICK_DRIVER_HAT_LEFT:
-      return StringUtils::Format("hat left");
+      return "hat left";
     default:
       break;
     }
@@ -126,6 +126,25 @@ std::string CStorageUtils::PrimitiveToString(const kodi::addon::DriverPrimitive&
         primitive.DriverIndex());
   case JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOTOR:
     return StringUtils::Format("motor %u", primitive.DriverIndex());
+  case JOYSTICK_DRIVER_PRIMITIVE_TYPE_KEY:
+    return StringUtils::Format("key \"%s\"", primitive.Keycode().c_str());
+  case JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOUSE_BUTTON:
+    return StringUtils::Format("mouse button %u", primitive.MouseIndex());
+  case JOYSTICK_DRIVER_PRIMITIVE_TYPE_RELPOINTER_DIRECTION:
+    switch (primitive.RelPointerDirection())
+    {
+    case JOYSTICK_DRIVER_RELPOINTER_UP:
+      return "pointer up";
+    case JOYSTICK_DRIVER_RELPOINTER_RIGHT:
+      return "pointer right";
+    case JOYSTICK_DRIVER_RELPOINTER_DOWN:
+      return "pointer down";
+    case JOYSTICK_DRIVER_RELPOINTER_LEFT:
+      return "pointer left";
+    default:
+      break;
+    }
+    break;
   default:
     break;
   }

--- a/src/storage/xml/ButtonMapDefinitions.h
+++ b/src/storage/xml/ButtonMapDefinitions.h
@@ -54,6 +54,7 @@
 #define BUTTONMAP_XML_ATTR_FEATURE_AXIS        "axis"
 #define BUTTONMAP_XML_ATTR_FEATURE_MOTOR       "motor"
 #define BUTTONMAP_XML_ATTR_FEATURE_KEY         "key"
+#define BUTTONMAP_XML_ATTR_FEATURE_MOUSE       "mouse"
 
 #define BUTTONMAP_XML_ATTR_DRIVER_INDEX        "index"
 #define BUTTONMAP_XML_ATTR_AXIS_CENTER         "center"

--- a/src/storage/xml/ButtonMapXml.cpp
+++ b/src/storage/xml/ButtonMapXml.cpp
@@ -211,7 +211,6 @@ bool CButtonMapXml::Serialize(const FeatureVector& features, TiXmlElement* pElem
         break;
       }
       case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
-      case JOYSTICK_FEATURE_TYPE_RELPOINTER:
       {
         if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ANALOG_STICK_UP), BUTTONMAP_XML_ELEM_UP))
           return false;
@@ -223,6 +222,22 @@ bool CButtonMapXml::Serialize(const FeatureVector& features, TiXmlElement* pElem
           return false;
 
         if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_ANALOG_STICK_LEFT), BUTTONMAP_XML_ELEM_LEFT))
+          return false;
+
+        break;
+      }
+      case JOYSTICK_FEATURE_TYPE_RELPOINTER:
+      {
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_RELPOINTER_UP), BUTTONMAP_XML_ELEM_UP))
+          return false;
+
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_RELPOINTER_DOWN), BUTTONMAP_XML_ELEM_DOWN))
+          return false;
+
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_RELPOINTER_RIGHT), BUTTONMAP_XML_ELEM_RIGHT))
+          return false;
+
+        if (!SerializePrimitiveTag(featureElem, feature.Primitive(JOYSTICK_RELPOINTER_LEFT), BUTTONMAP_XML_ELEM_LEFT))
           return false;
 
         break;
@@ -344,6 +359,16 @@ void CButtonMapXml::SerializePrimitive(TiXmlElement* pElement, const kodi::addon
         pElement->SetAttribute(BUTTONMAP_XML_ATTR_FEATURE_KEY, strPrimitive);
         break;
       }
+      case JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOUSE_BUTTON:
+      {
+        pElement->SetAttribute(BUTTONMAP_XML_ATTR_FEATURE_MOUSE, strPrimitive);
+        break;
+      }
+      case JOYSTICK_DRIVER_PRIMITIVE_TYPE_RELPOINTER_DIRECTION:
+      {
+        pElement->SetAttribute(BUTTONMAP_XML_ATTR_FEATURE_AXIS, strPrimitive);
+        break;
+      }
       default:
         break;
     }
@@ -440,7 +465,6 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
         break;
       }
       case JOYSTICK_FEATURE_TYPE_ANALOG_STICK:
-      case JOYSTICK_FEATURE_TYPE_RELPOINTER:
       {
         kodi::addon::DriverPrimitive up;
         kodi::addon::DriverPrimitive down;
@@ -480,6 +504,49 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
         feature.SetPrimitive(JOYSTICK_ANALOG_STICK_DOWN, down);
         feature.SetPrimitive(JOYSTICK_ANALOG_STICK_RIGHT, right);
         feature.SetPrimitive(JOYSTICK_ANALOG_STICK_LEFT, left);
+
+        break;
+      }
+      case JOYSTICK_FEATURE_TYPE_RELPOINTER:
+      {
+        kodi::addon::DriverPrimitive up;
+        kodi::addon::DriverPrimitive down;
+        kodi::addon::DriverPrimitive right;
+        kodi::addon::DriverPrimitive left;
+
+        bool bSuccess = true;
+
+        if (pUp && !DeserializePrimitive(pUp, up, strName))
+        {
+          esyslog("Feature \"%s\": <%s> tag is not a valid primitive", strName.c_str(), BUTTONMAP_XML_ELEM_UP);
+          bSuccess = false;
+        }
+
+        if (pDown && !DeserializePrimitive(pDown, down, strName))
+        {
+          esyslog("Feature \"%s\": <%s> tag is not a valid primitive", strName.c_str(), BUTTONMAP_XML_ELEM_DOWN);
+          bSuccess = false;
+        }
+
+        if (pRight && !DeserializePrimitive(pRight, right, strName))
+        {
+          esyslog("Feature \"%s\": <%s> tag is not a valid primitive", strName.c_str(), BUTTONMAP_XML_ELEM_RIGHT);
+          bSuccess = false;
+        }
+
+        if (pLeft && !DeserializePrimitive(pLeft, left, strName))
+        {
+          esyslog("Feature \"%s\": <%s> tag is not a valid primitive", strName.c_str(), BUTTONMAP_XML_ELEM_LEFT);
+          bSuccess = false;
+        }
+
+        if (!bSuccess)
+          return false;
+
+        feature.SetPrimitive(JOYSTICK_RELPOINTER_UP, up);
+        feature.SetPrimitive(JOYSTICK_RELPOINTER_DOWN, down);
+        feature.SetPrimitive(JOYSTICK_RELPOINTER_RIGHT, right);
+        feature.SetPrimitive(JOYSTICK_RELPOINTER_LEFT, left);
 
         break;
       }
@@ -597,9 +664,10 @@ bool CButtonMapXml::DeserializePrimitive(const TiXmlElement* pElement, kodi::add
   std::vector<std::pair<const char*, JOYSTICK_DRIVER_PRIMITIVE_TYPE>> types = {
     { BUTTONMAP_XML_ATTR_FEATURE_BUTTON, JOYSTICK_DRIVER_PRIMITIVE_TYPE_BUTTON },
     { BUTTONMAP_XML_ATTR_FEATURE_HAT, JOYSTICK_DRIVER_PRIMITIVE_TYPE_HAT_DIRECTION },
-    { BUTTONMAP_XML_ATTR_FEATURE_AXIS, JOYSTICK_DRIVER_PRIMITIVE_TYPE_SEMIAXIS },
+    { BUTTONMAP_XML_ATTR_FEATURE_AXIS, JOYSTICK_DRIVER_PRIMITIVE_TYPE_SEMIAXIS }, // Overloaded for relative pointer
     { BUTTONMAP_XML_ATTR_FEATURE_MOTOR, JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOTOR },
     { BUTTONMAP_XML_ATTR_FEATURE_KEY, JOYSTICK_DRIVER_PRIMITIVE_TYPE_KEY },
+    { BUTTONMAP_XML_ATTR_FEATURE_MOUSE, JOYSTICK_DRIVER_PRIMITIVE_TYPE_MOUSE_BUTTON },
   };
 
   for (const auto &it : types)


### PR DESCRIPTION
This PR allows mouse buttons and relative pointers to be stored in the buttonmap. An example buttonmap looks like:

```xml
<buttonmap>
    <device name="Mouse" provider="application">
        <controller id="game.controller.mouse">
            <feature name="button4" mouse="button4" />
            <feature name="button5" mouse="button5" />
            <feature name="horizwheelleft" mouse="horizwheelleft" />
            <feature name="horizwheelright" mouse="horizwheelright" />
            <feature name="left" mouse="left" />
            <feature name="middle" mouse="middle" />
            <feature name="pointer">
                <up axis="-y" />
                <down axis="+y" />
                <right axis="+x" />
                <left axis="-x" />
            </feature>
            <feature name="right" mouse="right" />
            <feature name="wheeldown" mouse="wheeldown" />
            <feature name="wheelup" mouse="wheelup" />
        </controller>
    </device>
</buttonmap>
```

Corresponds to https://github.com/xbmc/xbmc/pull/13482