### PR TITLE
linux: Add support for WeTek Gamepad

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Gamepad_17b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Gamepad_17b_8a.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Gamepad" provider="linux" buttoncount="17" axiscount="8">
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="10" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="6" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="13" />
+            <feature name="lefttrigger" button="8" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="7" />
+            <feature name="rightstick">
+                <up axis="-3" />
+                <down axis="+3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+            <feature name="rightthumb" button="14" />
+            <feature name="righttrigger" button="9" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="3" />
+            <feature name="y" button="4" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_11b_8a.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Microsoft X-Box 360 pad" provider="linux" buttoncount="11" axiscount="8">
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="8" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="9" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="10" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Add support for WeTek Gamepad gaming controller: https://wetek.com/ww/en/product/gamepad.

The gamepad can work either via USB connection, or via Bluetooth. In each mode it gets identified differently: for cable connection - Microsoft_X-Box_360_pad_11b_8a (045E:028E), for Bluetooth - Gamepad_17b_8a (05AC:022D). Hence this PR provides two button maps to support both modes.