### PR TITLE
Add NDO SW Pro Controller and 8bitdo NES30 Arcade

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_Arcade_x__10b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_Arcade_x__10b_8a.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="8Bitdo NES30 Arcade(x)" provider="linux" buttoncount="10" axiscount="8">
+        <configuration>
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="4" />
+            <feature name="down" axis="+1" />
+            <feature name="guide" button="7" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" axis="+5" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" axis="+2" />
+            <feature name="start" button="5" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+        <controller id="game.controller.genesis.6button">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="c" axis="+5" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="mode" button="6" />
+            <feature name="right" axis="+0" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-1" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+            <feature name="z" button="5" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="right" axis="+0" />
+            <feature name="select" button="3" />
+            <feature name="start" button="2" />
+            <feature name="up" axis="-1" />
+        </controller>
+        <controller id="game.controller.ps.gamepad">
+            <feature name="circle" button="0" />
+            <feature name="cross" button="1" />
+            <feature name="down" axis="+1" />
+            <feature name="left" axis="-0" />
+            <feature name="leftbumper" button="5" />
+            <feature name="lefttrigger" axis="+5" />
+            <feature name="right" axis="+0" />
+            <feature name="rightbumper" button="4" />
+            <feature name="righttrigger" axis="+2" />
+            <feature name="select" button="6" />
+            <feature name="square" button="3" />
+            <feature name="start" button="7" />
+            <feature name="triangle" button="2" />
+            <feature name="up" axis="-1" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Pro_Controller_16b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Pro_Controller_16b_6a.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Pro Controller" provider="linux" buttoncount="16" axiscount="6">
+        <configuration />
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="8" />
+            <feature name="down" axis="+5" />
+            <feature name="guide" button="12" />
+            <feature name="left" axis="-4" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="10" />
+            <feature name="lefttrigger" button="6" />
+            <feature name="right" axis="+4" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightthumb" button="11" />
+            <feature name="righttrigger" button="7" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+        <controller id="game.controller.genesis.6button">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="c" button="2" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="mode" button="8" />
+            <feature name="right" axis="+4" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+            <feature name="x" button="3" />
+            <feature name="y" button="4" />
+            <feature name="z" button="5" />
+        </controller>
+        <controller id="game.controller.nes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="right" axis="+4" />
+            <feature name="select" button="8" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+        </controller>
+        <controller id="game.controller.snes">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+5" />
+            <feature name="left" axis="-4" />
+            <feature name="leftbumper" button="4" />
+            <feature name="right" axis="+4" />
+            <feature name="rightbumper" button="5" />
+            <feature name="select" button="8" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-5" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Added Nintendo Switch Pro Controller and 8bitdo NES30 Arcade Stick maps to Kodi. Configured basic map setup for Kodi and for NES, SNES, Sega Genesis controllers.