### PR TITLE
Optimize controller transformer memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(JOYSTICK_SOURCES src/addon.cpp
                      src/buttonmapper/ControllerTransformer.cpp
                      src/buttonmapper/DriverGeometry.cpp
                      src/buttonmapper/JoystickFamily.cpp
+                     src/buttonmapper/StringRegistry.cpp
                      src/filesystem/DirectoryCache.cpp
                      src/filesystem/DirectoryUtils.cpp
                      src/filesystem/Filesystem.cpp
@@ -72,6 +73,7 @@ set(JOYSTICK_HEADERS src/addon.h
                      src/buttonmapper/ControllerTransformer.h
                      src/buttonmapper/DriverGeometry.h
                      src/buttonmapper/JoystickFamily.h
+                     src/buttonmapper/StringRegistry.h
                      src/filesystem/DirectoryCache.h
                      src/filesystem/DirectoryUtils.h
                      src/filesystem/Filesystem.h

--- a/src/buttonmapper/ButtonMapTypes.h
+++ b/src/buttonmapper/ButtonMapTypes.h
@@ -89,8 +89,8 @@ namespace JOYSTICK
    */
   struct ControllerTranslation
   {
-    std::string fromController;
-    std::string toController;
+    unsigned int fromController;
+    unsigned int toController;
 
     bool operator<(const ControllerTranslation& other) const
     {

--- a/src/buttonmapper/ControllerTransformer.cpp
+++ b/src/buttonmapper/ControllerTransformer.cpp
@@ -20,6 +20,7 @@
 
 #include "ControllerTransformer.h"
 #include "ButtonMapUtils.h"
+#include "StringRegistry.h"
 #include "storage/Device.h"
 #include "utils/CommonMacros.h"
 
@@ -54,9 +55,12 @@ namespace JOYSTICK
 // --- CControllerTransformer --------------------------------------------------
 
 CControllerTransformer::CControllerTransformer(CJoystickFamilyManager& familyManager) :
-  m_familyManager(familyManager)
+  m_familyManager(familyManager),
+  m_controllerIds(new CStringRegistry)
 {
 }
+
+CControllerTransformer::~CControllerTransformer() = default;
 
 void CControllerTransformer::OnAdd(const DevicePtr& driverInfo, const ButtonMap& buttonMap)
 {
@@ -101,8 +105,11 @@ void CControllerTransformer::AddControllerMap(const std::string& controllerFrom,
 {
   const bool bSwap = (controllerFrom >= controllerTo);
 
-  ControllerTranslation key = { bSwap ? controllerTo : controllerFrom,
-                                bSwap ? controllerFrom : controllerTo };
+  const unsigned int fromController = m_controllerIds->RegisterString(controllerFrom);
+  const unsigned int toController = m_controllerIds->RegisterString(controllerTo);
+
+  ControllerTranslation key = { bSwap ? toController : fromController,
+                                bSwap ? fromController : toController };
 
   FeatureMaps& featureMaps = m_controllerMap[key];
 
@@ -171,8 +178,11 @@ void CControllerTransformer::TransformFeatures(const kodi::addon::Joystick& driv
 {
   const bool bSwap = (fromController >= toController);
 
-  ControllerTranslation key = { bSwap ? toController : fromController,
-                                bSwap ? fromController : toController };
+  const unsigned int controllerFrom = m_controllerIds->RegisterString(fromController);
+  const unsigned int controllerTo = m_controllerIds->RegisterString(toController);
+
+  ControllerTranslation key = { bSwap ? controllerTo : controllerFrom,
+                                bSwap ? controllerFrom : controllerTo };
 
   const FeatureMaps& featureMaps = m_controllerMap[key];
 

--- a/src/buttonmapper/ControllerTransformer.h
+++ b/src/buttonmapper/ControllerTransformer.h
@@ -39,13 +39,14 @@ namespace addon
 namespace JOYSTICK
 {
   class CJoystickFamilyManager;
+  class CStringRegistry;
 
   class CControllerTransformer : public IDatabaseCallbacks
   {
   public:
     CControllerTransformer(CJoystickFamilyManager& familyManager);
 
-    virtual ~CControllerTransformer() = default;
+    virtual ~CControllerTransformer();
 
     // implementation of IDatabaseCallbacks
     virtual void OnAdd(const DevicePtr& driverInfo, const ButtonMap& buttonMap) override;
@@ -80,5 +81,6 @@ namespace JOYSTICK
     ControllerMap           m_controllerMap;
     DeviceSet               m_observedDevices;
     CJoystickFamilyManager& m_familyManager;
+    std::unique_ptr<CStringRegistry> m_controllerIds;
   };
 }

--- a/src/buttonmapper/StringRegistry.cpp
+++ b/src/buttonmapper/StringRegistry.cpp
@@ -1,0 +1,61 @@
+/*
+ *      Copyright (C) 2018 Garrett Brown
+ *      Copyright (C) 2018 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "StringRegistry.h"
+
+#include <algorithm>
+#include <iterator>
+
+using namespace JOYSTICK;
+
+unsigned int CStringRegistry::RegisterString(const std::string& str)
+{
+  unsigned int existingHandle;
+
+  // Match an existing string to avoid extra malloc
+  if (FindString(str, existingHandle))
+    return existingHandle;
+
+  // Append string
+  m_strings.emplace_back(str);
+
+  return m_strings.size() - 1;
+}
+
+const std::string &CStringRegistry::GetString(unsigned int handle)
+{
+  if (handle < m_strings.size())
+    return m_strings[handle];
+
+  const static std::string empty;
+  return empty;
+}
+
+bool CStringRegistry::FindString(const std::string &str, unsigned int &handle) const
+{
+  auto it = std::find(m_strings.begin(), m_strings.end(), str);
+  if (it != m_strings.end())
+  {
+    handle = std::distance(m_strings.begin(), it);
+    return true;
+  }
+
+  return false;
+}

--- a/src/buttonmapper/StringRegistry.h
+++ b/src/buttonmapper/StringRegistry.h
@@ -1,0 +1,41 @@
+/*
+ *      Copyright (C) 2018 Garrett Brown
+ *      Copyright (C) 2018 Team Kodi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace JOYSTICK
+{
+  class CStringRegistry
+  {
+  public:
+    CStringRegistry() = default;
+
+    unsigned int RegisterString(const std::string& str);
+
+    const std::string &GetString(unsigned int handle);
+
+  private:
+    bool FindString(const std::string &str, unsigned int &handle) const;
+
+    std::vector<std::string> m_strings;
+  };
+}


### PR DESCRIPTION
Switch from strings to int handles now that button maps (like https://github.com/xbmc/peripheral.joystick/pull/146) can contain over 60 controller profiles.

The transformation map storage is O(N<sup>2</sup>) in the number of profiles, so the large profile will thrash memory.