### PR TITLE
[Android] Add buttonmap for newer Shield controller

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.04_v0955_p7214_18b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.04_v0955_p7214_18b_8a.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="NVIDIA Corporation NVIDIA Controller v01.04" provider="android" vid="0955" pid="7214" buttoncount="18" axiscount="8">
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="12" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="16" />
+            <feature name="lefttrigger" axis="+5" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="13" />
+            <feature name="rightstick">
+                <up axis="-3" />
+                <down axis="+3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+            <feature name="rightthumb" button="17" />
+            <feature name="righttrigger" axis="+4" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="3" />
+            <feature name="y" button="4" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Button layout is the same as the older Shield controller in https://github.com/xbmc/peripheral.joystick/pull/151, so I copied the XML and changed the name and USB product ID. It should work.

Android actually maps pretty much every controller for its input API, so in the future we'll be able to use Android button mapping data to zero-config almost all controllers.