### PR TITLE
addon.xml.in: Bump to version 1.4.7 for Leia release

### DIFF
--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.4.6"
+  version="1.4.7"
   name="Joystick Support"
   provider-name="Team-Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
[45 commits](https://github.com/xbmc/peripheral.joystick/compare/v1.4.6...master) to master since v1.4.6. Let's bump the version for Leia.