### PR TITLE
Bump to v1.4.8 for Kodi 18.2 release

### DIFF
--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.4.7"
+  version="1.4.8"
   name="Joystick Support"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
The only relevant update is https://github.com/xbmc/peripheral.joystick/pull/161, but this gives us the opportunity to include the release name in the tag (an issue raised by https://github.com/xbmc/peripheral.joystick/issues/164).