### PR TITLE
[darwinEmbedded] Controller support for Extended and Micro gamepads

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_14b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_14b_4a.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Extended Gamepad" provider="darwinembedded" buttoncount="14" axiscount="4">
+        <controller id="game.controller.default">
+            <feature name="up" button="0" />
+            <feature name="down" button="1" />
+            <feature name="left" button="2" />
+            <feature name="right" button="3" />
+            <feature name="a" button="4" />
+            <feature name="b" button="5" />
+            <feature name="x" button="6" />
+            <feature name="y" button="7" />
+            <feature name="leftbumper" button="8" />
+            <feature name="lefttrigger" button="9" />
+            <feature name="rightbumper" button="10" />
+            <feature name="righttrigger" button="11" />
+            <feature name="start" button="12" />
+            <feature name="back" button="13" />
+            <feature name="leftstick">
+                <up axis="+1" />
+                <down axis="-1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="rightstick">
+                <up axis="+3" />
+                <down axis="-3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Micro_Gamepad_6b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Micro_Gamepad_6b.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Micro Gamepad" provider="darwinembedded" buttoncount="6">
+        <controller id="game.controller.default">
+            <feature name="up" button="0" />
+            <feature name="down" button="1" />
+            <feature name="left" button="2" />
+            <feature name="right" button="3" />
+            <feature name="start" button="4" />
+            <feature name="a" button="5" />
+            <feature name="x" button="6" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Apple supports gamepads with 2 specific button layous.
Extended is a traditional xbox style controller (14button, 2 axis)
Micro is similar to an NES controller (6 button - dpad + 2 buttons)

MicroGamepad can potentially handle motion, but i'll go with the easy assumption for now.

No need to merge this as yet, obviously still working on the rest of the pieces. Figure i'll just get this in place whilst i remember