### PR TITLE
[DarwinEmbedded] ExtendedGamepad Additional Button layouts

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_13b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_13b_4a.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Extended Gamepad" provider="darwinembedded" buttoncount="13" axiscount="4">
+        <controller id="game.controller.default">
+            <feature name="up" button="0" />
+            <feature name="down" button="1" />
+            <feature name="left" button="2" />
+            <feature name="right" button="3" />
+            <feature name="a" button="4" />
+            <feature name="b" button="5" />
+            <feature name="x" button="6" />
+            <feature name="y" button="7" />
+            <feature name="leftbumper" button="8" />
+            <feature name="lefttrigger" button="9" />
+            <feature name="rightbumper" button="10" />
+            <feature name="righttrigger" button="11" />
+            <feature name="start" button="12" />
+            <feature name="leftstick">
+                <up axis="+1" />
+                <down axis="-1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="rightstick">
+                <up axis="+3" />
+                <down axis="-3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_15b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_15b_4a.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <buttonmap>
-    <device name="Extended Gamepad" provider="darwinembedded" buttoncount="14" axiscount="4">
+    <device name="Extended Gamepad" provider="darwinembedded" buttoncount="15" axiscount="4">
         <controller id="game.controller.default">
             <feature name="up" button="0" />
             <feature name="down" button="1" />
@@ -15,7 +15,8 @@
             <feature name="rightbumper" button="10" />
             <feature name="righttrigger" button="11" />
             <feature name="start" button="12" />
-            <feature name="back" button="13" />
+            <feature name="leftthumb" button="14" />
+            <feature name="rightthumb" button="15" />
             <feature name="leftstick">
                 <up axis="+1" />
                 <down axis="-1" />

--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_16b_4a.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Extended Gamepad" provider="darwinembedded" buttoncount="16" axiscount="4">
+        <controller id="game.controller.default">
+            <feature name="up" button="0" />
+            <feature name="down" button="1" />
+            <feature name="left" button="2" />
+            <feature name="right" button="3" />
+            <feature name="a" button="4" />
+            <feature name="b" button="5" />
+            <feature name="x" button="6" />
+            <feature name="y" button="7" />
+            <feature name="leftbumper" button="8" />
+            <feature name="lefttrigger" button="9" />
+            <feature name="rightbumper" button="10" />
+            <feature name="righttrigger" button="11" />
+            <feature name="start" button="12" />
+            <feature name="back" button="13" />
+            <feature name="leftthumb" button="14" />
+            <feature name="rightthumb" button="15" />
+            <feature name="leftstick">
+                <up axis="+1" />
+                <down axis="-1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="rightstick">
+                <up axis="+3" />
+                <down axis="-3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
GCController API supports upto 16 Buttons on a controller
3 buttons are optional - Thumbstick button L/R and Options button
    
PS4 dual shock - 16b_4a
XBOX wireless Controller - 16b_4a
Steelseries Nimbus - 15b_4a
    
Some older MFI controllers predate the thumbstick button and Option button - 13b_4a