### PR TITLE
[Matrix] correction release, german language add and debian build update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,37 @@ matrix:
       dist: xenial
       sudo: required
       compiler: clang
+    - os: linux
+      dist: bionic
+      sudo: required
+      compiler: gcc
+      env: DEBIAN_BUILD=true
+    - os: linux
+      dist: focal
+      sudo: required
+      compiler: gcc
+      env: DEBIAN_BUILD=true
     - os: osx
       osx_image: xcode10.2
+
+before_install:
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
 
 #
 # The addon source is automatically checked out in $TRAVIS_BUILD_DIR,
 # we'll put the Kodi source on the same level
 #
 before_script:
-  - cd $TRAVIS_BUILD_DIR/..
-  - git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git
-  - cd ${app_id} && mkdir build && cd build
-  - mkdir -p definition/${app_id}
-  - echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt
-  - cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons
+  - if [[ $DEBIAN_BUILD != true ]]; then cd $TRAVIS_BUILD_DIR/..; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then git clone --branch master --depth=1 https://github.com/xbmc/xbmc.git; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir build && cd build; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then mkdir -p definition/${app_id}; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then echo ${app_id} $TRAVIS_BUILD_DIR $TRAVIS_COMMIT > definition/${app_id}/${app_id}.txt; fi
+  - if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=$TRAVIS_BUILD_DIR/.. -DADDONS_DEFINITION_DIR=$TRAVIS_BUILD_DIR/build/definition -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/../xbmc/addons -DPACKAGE_ZIP=1 $TRAVIS_BUILD_DIR/../xbmc/cmake/addons; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep $TRAVIS_BUILD_DIR; fi
 
-script: make
+script:
+  - if [[ $DEBIAN_BUILD != true ]]; then make; fi
+  - if [[ $DEBIAN_BUILD == true ]]; then ./debian-addon-package-test.sh $TRAVIS_BUILD_DIR; fi

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Priority: extra
 Maintainer: wsnipex <wsnipex@a1.net>
 Build-Depends: debhelper (>= 9.0.0), cmake, libtinyxml-dev,
                kodi-addon-dev, pkg-config, libudev-dev
-Standards-Version: 3.9.6
+Standards-Version: 4.1.2
 Section: libs
 
 Package: kodi-peripheral-joystick

--- a/debian/rules
+++ b/debian/rules
@@ -13,10 +13,7 @@
 	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1
-
-override_dh_strip:
-	dh_strip -pkodi-peripheral-joystick --dbg-package=kodi-peripheral-joystick-dbg
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=1 -DUSE_LTO=1
 
 override_dh_installdocs:
 	dh_installdocs --link-doc=kodi-peripheral-joystick

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)

--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -11,7 +11,9 @@
     provides_buttonmaps="true"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
+    <summary lang="de_DE">Kodi Joystick Library</summary>
     <summary lang="en_GB">Kodi Joystick Library</summary>
+    <description lang="de_DE">Diese Bibliothek enthält Joystick-Treiber und Schaltflächenzuordnungen. Es werden mehrere Joystick-APIs unterstützt, darunter DirectX, XInput, SDL und die Linux-Joystick-API.</description>
     <description lang="en_GB">This library provides joystick drivers and button maps. Multiple joystick APIs are supported, including DirectX, XInput, SDL and the Linux Joystick API.</description>
     <license>GPL-2.0-or-later</license>
     <source>https://github.com/xbmc/peripheral.joystick</source>

--- a/peripheral.joystick/addon.xml.in
+++ b/peripheral.joystick/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.joystick"
-  version="1.5.3"
+  version="1.6.1"
   name="Joystick Support"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/peripheral.joystick/resources/language/resource.language.de_de/strings.po
+++ b/peripheral.joystick/resources/language/resource.language.de_de/strings.po
@@ -18,23 +18,23 @@ msgstr ""
 
 msgctxt "#30000"
 msgid "Driver settings"
-msgstr ""
+msgstr "Treibereinstellungen"
 
 msgctxt "#30001"
 msgid "Joystick driver"
-msgstr ""
+msgstr "Joystick-Treiber"
 
 msgctxt "#30002"
 msgid "None"
-msgstr ""
+msgstr "Keiner"
 
 msgctxt "#30003"
 msgid "Enable XInput"
-msgstr ""
+msgstr "Aktiviere XInput"
 
 msgctxt "#30004"
 msgid "Enable DirectInput"
-msgstr ""
+msgstr "Aktiviere DirectInput"
 
 #. Do not translate
 msgctxt "#30005"
@@ -58,4 +58,4 @@ msgstr ""
 
 #msgctxt "#21475"
 #msgid "Both"
-#msgstr ""
+#msgstr "Beide"


### PR DESCRIPTION
Correction release for 2 errors from the previous one:
1. In the last release 1.6.0 was accidentally used instead of 1.5.3
2. The release was too fast for Debian / Ubuntu build and the necessary Kodi version wasn't available, so build on the old version

Further I has added:
- German translation
- To make also debian build with Travis
  - this then report bad Debian if differences in API (this works only if addon also need changes)
- Bit update of debian build code

Releated to https://github.com/xbmc/peripheral.joystick/issues/184

Because of translation, I think we have to get Transifex Fit for our addons again soon, nothing works with them for a long time (addon updates are missing there).