### PR TITLE
Add buttonmap for DualShock4 connecting to macOS via BT.

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/DUALSHOCK_4_Wireless_Controller_v054C_p09CC_14b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/DUALSHOCK_4_Wireless_Controller_v054C_p09CC_14b_6a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="DUALSHOCK 4 Wireless Controller" provider="cocoa" vid="054C" pid="09CC" buttoncount="14" axiscount="6">
+        <configuration>
+            <axis index="4" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="1" />
+            <feature name="b" button="2" />
+            <feature name="back" button="8" />
+            <feature name="guide" button="13" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="10" />
+            <feature name="lefttrigger" axis="+4" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-3" />
+                <down axis="+3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+            <feature name="rightthumb" button="11" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="9" />
+            <feature name="x" button="0" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
Tested using DualShock 4 (2nd gen) controller connected via bluetooth to a Macbook running macOS 11.2.3.

It advertises itself as `"DUALSHOCK 4 Wireless Controller", axes: 6, hats: 0, buttons: 14`, not as "Wireless Controller" specified in the [existing button map](https://github.com/xbmc/peripheral.joystick/blob/79d166a1519305f05ebf2db24a7fbd6bb7633083/peripheral.joystick/resources/buttonmaps/xml/cocoa/Wireless_Controller_v054C_p09CC_14b_6a.xml).

So even though the vid/pid and the rest are the same, the existing button map [is not used](https://github.com/xbmc/peripheral.joystick/blob/79d166a1519305f05ebf2db24a7fbd6bb7633083/src/storage/Device.cpp#L34).

As Joystick families (#32) do not seem to be fully implemented (adding a new entry to the joystickfamilies.xml didn't have an effect and I don't see where it's used in the code), I solve this by duplicating the existing button map with a different name.