### PR TITLE
[GCController] rename darwinembedded provider to GCController

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_13b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_13b_4a.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Extended Gamepad" provider="GCController" buttoncount="13" axiscount="4">
+        <controller id="game.controller.default">
+            <feature name="up" button="0" />
+            <feature name="down" button="1" />
+            <feature name="left" button="2" />
+            <feature name="right" button="3" />
+            <feature name="a" button="4" />
+            <feature name="b" button="5" />
+            <feature name="x" button="6" />
+            <feature name="y" button="7" />
+            <feature name="leftbumper" button="8" />
+            <feature name="lefttrigger" button="9" />
+            <feature name="rightbumper" button="10" />
+            <feature name="righttrigger" button="11" />
+            <feature name="start" button="12" />
+            <feature name="leftstick">
+                <up axis="+1" />
+                <down axis="-1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="rightstick">
+                <up axis="+3" />
+                <down axis="-3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_15b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_15b_4a.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Extended Gamepad" provider="GCController" buttoncount="15" axiscount="4">
+        <controller id="game.controller.default">
+            <feature name="up" button="0" />
+            <feature name="down" button="1" />
+            <feature name="left" button="2" />
+            <feature name="right" button="3" />
+            <feature name="a" button="4" />
+            <feature name="b" button="5" />
+            <feature name="x" button="6" />
+            <feature name="y" button="7" />
+            <feature name="leftbumper" button="8" />
+            <feature name="lefttrigger" button="9" />
+            <feature name="rightbumper" button="10" />
+            <feature name="righttrigger" button="11" />
+            <feature name="start" button="12" />
+            <feature name="leftthumb" button="14" />
+            <feature name="rightthumb" button="15" />
+            <feature name="leftstick">
+                <up axis="+1" />
+                <down axis="-1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="rightstick">
+                <up axis="+3" />
+                <down axis="-3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_16b_4a.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Extended Gamepad" provider="GCController" buttoncount="16" axiscount="4">
+        <controller id="game.controller.default">
+            <feature name="up" button="0" />
+            <feature name="down" button="1" />
+            <feature name="left" button="2" />
+            <feature name="right" button="3" />
+            <feature name="a" button="4" />
+            <feature name="b" button="5" />
+            <feature name="x" button="6" />
+            <feature name="y" button="7" />
+            <feature name="leftbumper" button="8" />
+            <feature name="lefttrigger" button="9" />
+            <feature name="rightbumper" button="10" />
+            <feature name="righttrigger" button="11" />
+            <feature name="start" button="12" />
+            <feature name="back" button="13" />
+            <feature name="leftthumb" button="14" />
+            <feature name="rightthumb" button="15" />
+            <feature name="leftstick">
+                <up axis="+1" />
+                <down axis="-1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="rightstick">
+                <up axis="+3" />
+                <down axis="-3" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/GCController/Micro_Gamepad_6b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/GCController/Micro_Gamepad_6b.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Micro Gamepad" provider="GCController" buttoncount="6">
+        <controller id="game.controller.default">
+            <feature name="up" button="0" />
+            <feature name="down" button="1" />
+            <feature name="left" button="2" />
+            <feature name="right" button="3" />
+            <feature name="start" button="4" />
+            <feature name="a" button="5" />
+            <feature name="x" button="6" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
GCController mappings are universal to all apple devices that utilise
the GCController framework (ios/tvos/osx). Rename to match peripheralbus
rename in kodi

This pairs with https://github.com/xbmc/xbmc/pull/18790 in core for the more generic name of GCController for the provider

Note: the core change will be v20+, v19 will still be darwinembedded, so not sure if a straight folder rename is the correct way, or if i should duplicate the buttonmaps and keep both providers available for easier versioning of peripheral.joystick