### PR TITLE
Xbox One controller buttonmaps for linux/udev

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad_11b_8a.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Microsoft X-Box One pad" provider="linux" buttoncount="11" axiscount="8">
+        <configuration>
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="8" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="9" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="10" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_Wireless_Controller_13b_8a.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Sony Interactive Entertainment Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
+        <configuration>
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="8" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="10" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="11" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="12" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="9" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="3" />
+            <feature name="y" button="2" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_One_Wireless_Controller_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_One_Wireless_Controller_11b_8a.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Xbox One Wireless Controller" provider="linux" buttoncount="11" axiscount="8">
+        <configuration>
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="8" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="9" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="10" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_One_Wireless_Controller_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_One_Wireless_Controller_11b_8a.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Xbox One Wireless Controller" provider="udev" buttoncount="11" axiscount="8">
+        <configuration />
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+7" />
+            <feature name="guide" button="8" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="9" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="10" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
## Description

As title says, adds a linux buttonmap for Xbox One controller via usb, and a linux/udev controller for Xbox One wireless controller adapter via the xow userspace driver.

## Motivation and context

I invested in a set of Xbox One controllers and a PC adapter, so let's get the buttonmaps upstream.