### PR TITLE
[linux/udev] Fix cmake warning with find_package_handle_standard_args

### DIFF
--- a/cmake/Findudev.cmake
+++ b/cmake/Findudev.cmake
@@ -60,7 +60,7 @@ find_path(UDEV_INCLUDE_DIR
 	)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(UDEV
+find_package_handle_standard_args(udev
 	DEFAULT_MSG
 	UDEV_LIBRARY
 	UDEV_INCLUDE_DIR


### PR DESCRIPTION
Warning message before the fix:

-- Checking for module 'libudev'
--   Found libudev, version 250
CMake Warning (dev) at build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/share/cmake-3.23/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (UDEV) does
  not match the name of the calling package (udev).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/Findudev.cmake:63 (find_package_handle_standard_args)
  CMakeLists.txt:203 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
-- Found UDEV: build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libudev.so

After the fixed - the build is clean:

-- Checking for module 'libudev'
--   Found libudev, version 250
-- Found udev: build.LibreELEC-Generic.x86_64-11.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/lib/libudev.so