### PR TITLE
Update Wireless PS4 controller button map

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" ?>
 <buttonmap>
     <device name="Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
-        <configuration />
+        <configuration>
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
         <controller id="game.controller.default">
             <feature name="a" button="0" />
             <feature name="b" button="1" />
@@ -17,7 +22,7 @@
                 <left axis="-0" />
             </feature>
             <feature name="leftthumb" button="11" />
-            <feature name="lefttrigger" button="6" />
+            <feature name="lefttrigger" axis="+2" />
             <feature name="right" axis="+6" />
             <feature name="rightbumper" button="5" />
             <feature name="rightstick">
@@ -27,132 +32,11 @@
                 <left axis="-3" />
             </feature>
             <feature name="rightthumb" button="12" />
-            <feature name="righttrigger" button="7" />
+            <feature name="righttrigger" axis="+5" />
             <feature name="start" button="9" />
             <feature name="up" axis="-7" />
             <feature name="x" button="3" />
             <feature name="y" button="2" />
-        </controller>
-        <controller id="game.controller.dreamcast">
-            <feature name="a" button="0" />
-            <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
-            </feature>
-            <feature name="b" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+6" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="10" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="2" />
-        </controller>
-        <controller id="game.controller.gba">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-        </controller>
-        <controller id="game.controller.genesis">
-            <feature name="a" button="3" />
-            <feature name="b" button="0" />
-            <feature name="c" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="mode" button="8" />
-            <feature name="right" axis="+6" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="4" />
-            <feature name="z" button="5" />
-        </controller>
-        <controller id="game.controller.n64">
-            <feature name="a" button="0" />
-            <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
-            </feature>
-            <feature name="b" button="3" />
-            <feature name="cdown" axis="+4" />
-            <feature name="cleft" axis="-3" />
-            <feature name="cright" axis="+3" />
-            <feature name="cup" axis="-4" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="start" button="10" />
-            <feature name="up" axis="-7" />
-            <feature name="z" button="12" />
-        </controller>
-        <controller id="game.controller.nes">
-            <feature name="a" button="0" />
-            <feature name="b" button="3" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-        </controller>
-        <controller id="game.controller.ps">
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="11" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
-            </feature>
-            <feature name="lefttrigger" button="6" />
-            <feature name="r3" button="12" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
-            </feature>
-            <feature name="righttrigger" button="7" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" axis="-7" />
-        </controller>
-        <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
         </controller>
     </device>
 </buttonmap>


### PR DESCRIPTION
## Description

This PR updates the Wireless PS4 controller (both v1 and v2) added in https://github.com/xbmc/peripheral.joystick/pull/117 to use analog axes for the triggers instead of digital buttons.

The central problem is due to an astrological phenomenon colloquially known as "joystick driver fuckery". To make our lives more difficult, the linux driver for PS4 controllers sends both a button press and an anolog axis for each trigger. The button press is sent when the analog axis crosses the 0.5 threshold. However, the button mapper waits for a slightly higher threshold for analog axes, causing the digital button to be used for the trigger. Even worse, when the axis _is_ detected, it is erroneously assigned to the next trigger and causes "skipping" in the mapper.

To allow for mapping PS4 controllers, I added an "Ignore Input" button which I describe here: https://kodi.wiki/view/HOW-TO:PlayStation_4_controller

The configuration block in this diff is what the output of the "Ignore Input" approach created.

(Additional controller profiles not needed, Kodi should automatically translate to other controllers when the default map is known.)

## Motivation and context

While working on Smart Home (https://github.com/xbmc/xbmc/pull/21183) and connecting my LEGO train to the PS4 controller output, I noticed that the train could only go zero throttle or full throttle.

[![Lego Train via PS4 Controller](https://img.youtube.com/vi/zMA9HYPH4Tw/hqdefault.jpg)](https://youtu.be/zMA9HYPH4Tw)

And let me tell you, at full throttle of LEGO 9v motors overvolted to 12V and pumped via a high current robotics motor controller, the train FLIES off the track.

## Related PRs

Introduced in https://github.com/xbmc/peripheral.joystick/pull/117
