### PR TITLE
udev: close file descriptor if joystick init is not successful

### DIFF
--- a/src/api/udev/JoystickUdev.cpp
+++ b/src/api/udev/JoystickUdev.cpp
@@ -76,14 +76,18 @@ bool CJoystickUdev::Initialize(void)
   return m_bInitialized;
 }
 
-void CJoystickUdev::Deinitialize(void)
+void CJoystickUdev::Close(void)
 {
   if (m_fd >= 0)
   {
     close(m_fd);
     m_fd = INVALID_FD;
   }
+}
 
+void CJoystickUdev::Deinitialize(void)
+{
+  Close();
   CJoystick::Deinitialize();
 }
 
@@ -242,11 +246,17 @@ bool CJoystickUdev::OpenJoystick()
     return false;
 
   if (ioctl(m_fd, EVIOCGBIT(0, sizeof(evbit)), evbit) < 0)
+  {
+    Close();
     return false;
+  }
 
   // Has to at least support EV_KEY interface
   if (!test_bit(EV_KEY, evbit))
+  {
+    Close();
     return false;
+  }
 
   return true;
 }

--- a/src/api/udev/JoystickUdev.h
+++ b/src/api/udev/JoystickUdev.h
@@ -67,6 +67,7 @@ namespace JOYSTICK
   private:
     void UpdateMotorState(const std::array<uint16_t, MOTOR_COUNT>& motors);
     void Play(bool bPlayStop);
+    void Close(void);
 
     struct Axis
     {


### PR DESCRIPTION
I discovered a bug where Kodi keeps opening a joystick device until the number of open file descriptors reaches the kernel limit ("Too many open files").

E.g.:
```
# lsof -p $(pidof kodi.bin) | grep js0 | wc -l
355
```

The "joystick" in question:
```
/dev/input/by-id/usb-MemsArt_MA144_RF_Controller-event-if02 -> ../event8
/dev/input/by-id/usb-MemsArt_MA144_RF_Controller-event-kbd -> ../event5
/dev/input/by-id/usb-MemsArt_MA144_RF_Controller-if01-event-mouse -> ../event6
/dev/input/by-id/usb-MemsArt_MA144_RF_Controller-if01-mouse -> ../mouse1
/dev/input/by-id/usb-MemsArt_MA144_RF_Controller-if03-event-joystick -> ../event9
/dev/input/by-id/usb-MemsArt_MA144_RF_Controller-if03-joystick -> ../js0
```

I must admit i didn't investigate what part of code kept opening the device, but my patch fixes the problem of leaving FDs open.