### PR TITLE
Peripheral API v3.0.0: Show "actual" controllers in the UI

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -111,6 +111,22 @@ PERIPHERAL_ERROR CPeripheralJoystick::GetJoystickInfo(unsigned int index, kodi::
   return PERIPHERAL_NO_ERROR;
 }
 
+PERIPHERAL_ERROR CPeripheralJoystick::GetAppearance(const kodi::addon::Joystick& joystick, std::string& controllerId)
+{
+  if (!CStorageManager::Get().GetAppearance(joystick, controllerId))
+    controllerId.clear();
+
+  return PERIPHERAL_NO_ERROR;
+}
+
+PERIPHERAL_ERROR CPeripheralJoystick::SetAppearance(const kodi::addon::Joystick& joystick, const std::string& controllerId)
+{
+  if (!CStorageManager::Get().SetAppearance(joystick, controllerId))
+    return PERIPHERAL_ERROR_FAILED;
+
+  return PERIPHERAL_NO_ERROR;
+}
+
 PERIPHERAL_ERROR CPeripheralJoystick::GetFeatures(const kodi::addon::Joystick& joystick,
                                                   const std::string& controller_id,
                                                   std::vector<kodi::addon::JoystickFeature>& features)

--- a/src/addon.h
+++ b/src/addon.h
@@ -33,6 +33,8 @@ public:
   PERIPHERAL_ERROR GetEvents(std::vector<kodi::addon::PeripheralEvent>& events) override;
   bool SendEvent(const kodi::addon::PeripheralEvent& event) override;
   PERIPHERAL_ERROR GetJoystickInfo(unsigned int index, kodi::addon::Joystick& info) override;
+  PERIPHERAL_ERROR GetAppearance(const kodi::addon::Joystick& joystick, std::string& controllerId) override;
+  PERIPHERAL_ERROR SetAppearance(const kodi::addon::Joystick& joystick, const std::string& controllerId) override;
   PERIPHERAL_ERROR GetFeatures(const kodi::addon::Joystick& joystick,
                                const std::string& controller_id,
                                std::vector<kodi::addon::JoystickFeature>& features) override;

--- a/src/buttonmapper/ButtonMapper.h
+++ b/src/buttonmapper/ButtonMapper.h
@@ -42,12 +42,12 @@ namespace JOYSTICK
     IDatabaseCallbacks* GetCallbacks();
 
     bool GetFeatures(const kodi::addon::Joystick& joystick, const std::string& strDeviceId, FeatureVector& features);
+    ButtonMap GetButtonMap(const kodi::addon::Joystick& joystick) const;
 
     void RegisterDatabase(const DatabasePtr& database);
     void UnregisterDatabase(const DatabasePtr& database);
 
   private:
-    ButtonMap GetButtonMap(const kodi::addon::Joystick& joystick) const;
     static void MergeButtonMap(ButtonMap& accumulatedMap, const ButtonMap& newFeatures);
     static void MergeFeatures(FeatureVector& features, const FeatureVector& newFeatures);
     bool GetFeatures(const kodi::addon::Joystick& joystick, ButtonMap buttonMap, const std::string& controllerId, FeatureVector& features);

--- a/src/filesystem/DirectoryCache.cpp
+++ b/src/filesystem/DirectoryCache.cpp
@@ -96,3 +96,8 @@ void CDirectoryCache::UpdateDirectory(const std::string& path, const std::vector
   timestamp = std::chrono::steady_clock::now();
   cachedItems = items;
 }
+
+void CDirectoryCache::ClearCache()
+{
+  m_cache.clear();
+}

--- a/src/filesystem/DirectoryCache.h
+++ b/src/filesystem/DirectoryCache.h
@@ -38,6 +38,8 @@ namespace JOYSTICK
     bool GetDirectory(const std::string& path, std::vector<kodi::vfs::CDirEntry>& items);
     void UpdateDirectory(const std::string& path, const std::vector<kodi::vfs::CDirEntry>& items);
 
+    void ClearCache();
+
   private:
     IDirectoryCacheCallback* m_callbacks;
 

--- a/src/storage/ButtonMap.cpp
+++ b/src/storage/ButtonMap.cpp
@@ -253,7 +253,7 @@ void CButtonMap::Sanitize(FeatureVector& features, const std::string& controller
 
       if (!bIsValid)
       {
-        dsyslog("%s: Removing %s from button map", controllerId.c_str(), feature.Name().c_str());
+        dsyslog("Removing %s from button map, is %s installed?", feature.Name().c_str(), controllerId.c_str());
         return true;
       }
 

--- a/src/storage/DeviceConfiguration.cpp
+++ b/src/storage/DeviceConfiguration.cpp
@@ -15,13 +15,15 @@ using namespace JOYSTICK;
 
 void CDeviceConfiguration::Reset(void)
 {
+  m_appearance.clear();
   m_axes.clear();
   m_buttons.clear();
 }
 
 bool CDeviceConfiguration::IsEmpty() const
 {
-  return m_axes.empty() &&
+  return m_appearance.empty() &&
+         m_axes.empty() &&
          m_buttons.empty();
 }
 

--- a/src/storage/DeviceConfiguration.h
+++ b/src/storage/DeviceConfiguration.h
@@ -13,6 +13,7 @@
 #include "buttonmapper/ButtonMapTypes.h"
 
 #include <map>
+#include <string>
 
 namespace JOYSTICK
 {
@@ -28,6 +29,7 @@ namespace JOYSTICK
 
     bool IsEmpty() const;
 
+    const std::string& GetAppearance(void) const { return m_appearance; }
           AxisConfigurationMap&   Axes(void)                       { return m_axes; }
     const AxisConfigurationMap&   Axes(void) const                 { return m_axes; }
     const AxisConfiguration&      Axis(unsigned int index) const;
@@ -38,6 +40,7 @@ namespace JOYSTICK
     void                          GetAxisConfigs(FeatureVector& features) const;
     void                          GetAxisConfig(kodi::addon::DriverPrimitive& primitive) const;
 
+    void SetAppearance(const std::string& controllerId) { m_appearance = controllerId; }
     void SetAxis(unsigned int index, const AxisConfiguration& config)     { m_axes[index] = config; }
     void SetButton(unsigned int index, const ButtonConfiguration& config) { m_buttons[index] = config; }
     void SetAxisConfigs(const FeatureVector& features);
@@ -46,6 +49,7 @@ namespace JOYSTICK
 
   private:
     // Configuration parameters
+    std::string m_appearance;
     AxisConfigurationMap m_axes;
     ButtonConfigurationMap m_buttons;
   };

--- a/src/storage/IDatabase.h
+++ b/src/storage/IDatabase.h
@@ -43,6 +43,16 @@ namespace JOYSTICK
     virtual ~IDatabase(void) { }
 
     /*!
+     * \copydoc CStorageManager::GetAppearance()
+     */
+    virtual bool GetAppearance(const kodi::addon::Joystick& driverInfo, std::string& controllerId) = 0;
+
+    /*!
+     * \copydoc CStorageManager::SetAppearance()
+     */
+    virtual bool SetAppearance(const kodi::addon::Joystick& driverInfo, const std::string& controllerId) = 0;
+
+    /*!
      * \copydoc CStorageManager::GetFeatures()
      */
     virtual const ButtonMap& GetButtonMap(const kodi::addon::Joystick& driverInfo) = 0;

--- a/src/storage/JustABunchOfFiles.h
+++ b/src/storage/JustABunchOfFiles.h
@@ -37,6 +37,8 @@ namespace JOYSTICK
     bool AddResource(CButtonMap* resource);
     void RemoveResource(const std::string& strPath);
 
+    bool GetAppearance(const CDevice& deviceInfo, std::string& controllerId) const;
+    bool SetAppearance(const CDevice& deviceInfo, const std::string& controllerId);
     bool GetIgnoredPrimitives(const CDevice& deviceInfo, PrimitiveVector& primitives) const;
     void SetIgnoredPrimitives(const CDevice& deviceInfo, const PrimitiveVector& primitives);
 
@@ -67,6 +69,8 @@ namespace JOYSTICK
     virtual ~CJustABunchOfFiles(void);
 
     // implementation of IDatabase
+    virtual bool GetAppearance(const kodi::addon::Joystick& driverInfo, std::string& controllerId) override;
+    virtual bool SetAppearance(const kodi::addon::Joystick& driverInfo, const std::string& controllerId) override;
     virtual const ButtonMap& GetButtonMap(const kodi::addon::Joystick& driverInfo) override;
     virtual bool MapFeatures(const kodi::addon::Joystick& driverInfo,
                              const std::string& controllerId,

--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -98,6 +98,35 @@ void CStorageManager::Deinitialize(void)
   m_peripheralLib = nullptr;
 }
 
+bool CStorageManager::GetAppearance(const kodi::addon::Joystick& joystick, std::string& controllerId)
+{
+  for (DatabaseVector::const_iterator it = m_databases.begin(); it != m_databases.end(); ++it)
+  {
+    if ((*it)->GetAppearance(joystick, controllerId))
+      return true;
+  }
+
+  // Fall back to deducing controller profile based on mapping
+  ButtonMap buttonMap = m_buttonMapper->GetButtonMap(joystick);
+  if (buttonMap.size() == 1)
+  {
+     controllerId = buttonMap.begin()->first;
+     return true;
+  }
+
+  return false;
+}
+
+bool CStorageManager::SetAppearance(const kodi::addon::Joystick& joystick, const std::string& controllerId)
+{
+  bool bSuccess = false;
+
+  for (DatabaseVector::const_iterator it = m_databases.begin(); it != m_databases.end(); ++it)
+    bSuccess |= (*it)->SetAppearance(joystick, controllerId);
+
+  return bSuccess;
+}
+
 void CStorageManager::GetFeatures(const kodi::addon::Joystick& joystick,
                                   const std::string& strControllerId,
                                   FeatureVector& features)

--- a/src/storage/StorageManager.h
+++ b/src/storage/StorageManager.h
@@ -78,6 +78,32 @@ namespace JOYSTICK
     void Deinitialize(void);
 
     /*!
+     * \brief Get the controller profile that best represents the device
+     *
+     * \param joystick The device's joystick properties; unknown values may be
+     *                 left at their default
+     * \param controllerId The controller profile, e.g. game.controller.default,
+     *                     or unmodified if false is returned
+     *
+     * \return True if the controller ID was loaded from a storage backend,
+     * false on error
+     */
+    bool GetAppearance(const kodi::addon::Joystick& joystick, std::string& controllerId);
+
+    /*!
+     * \brief Set the controller profile that best represents the device
+     *
+     * \param joystick The device's joystick properties; unknown values may be
+     *                 left at their default
+     * \param controllerId The controller profile, e.g. game.controller.default,
+     *                     or empty to unset the appearance
+     *
+     * \return True if the controller ID was loaded from a storage backend,
+     * false on error
+     */
+    bool SetAppearance(const kodi::addon::Joystick& joystick, const std::string& controllerId);
+
+    /*!
      * \brief Get the map of features to driver primitives from a storage backend
      *
      * \param joystick      The device's joystick properties; unknown values may be left at their default

--- a/src/storage/api/DatabaseJoystickAPI.cpp
+++ b/src/storage/api/DatabaseJoystickAPI.cpp
@@ -12,6 +12,16 @@
 
 using namespace JOYSTICK;
 
+bool CDatabaseJoystickAPI::GetAppearance(const kodi::addon::Joystick& driverInfo, std::string& controllerId)
+{
+  return false;
+}
+
+bool CDatabaseJoystickAPI::SetAppearance(const kodi::addon::Joystick& driverInfo, const std::string& controllerId)
+{
+  return false;
+}
+
 const ButtonMap& CDatabaseJoystickAPI::GetButtonMap(const kodi::addon::Joystick& driverInfo)
 {
   return CJoystickManager::Get().GetButtonMap(driverInfo.Provider());

--- a/src/storage/api/DatabaseJoystickAPI.h
+++ b/src/storage/api/DatabaseJoystickAPI.h
@@ -20,6 +20,8 @@ namespace JOYSTICK
     virtual ~CDatabaseJoystickAPI(void) { }
 
     // implementation of IDatabase
+    virtual bool GetAppearance(const kodi::addon::Joystick& driverInfo, std::string& controllerId) override;
+    virtual bool SetAppearance(const kodi::addon::Joystick& driverInfo, const std::string& controllerId) override;
     virtual const ButtonMap& GetButtonMap(const kodi::addon::Joystick& driverInfo) override;
     virtual bool MapFeatures(const kodi::addon::Joystick& driverInfo, const std::string& controllerId, const FeatureVector& features) override;
     virtual bool GetIgnoredPrimitives(const kodi::addon::Joystick& driverInfo, PrimitiveVector& primitives) override;

--- a/src/storage/xml/ButtonMapDefinitions.h
+++ b/src/storage/xml/ButtonMapDefinitions.h
@@ -11,6 +11,7 @@
 #define BUTTONMAP_XML_ROOT                     "buttonmap"
 #define BUTTONMAP_XML_ELEM_DEVICE              "device"
 #define BUTTONMAP_XML_ELEM_CONFIGURATION       "configuration"
+#define BUTTONMAP_XML_ELEM_APPEARANCE          "appearance"
 #define BUTTONMAP_XML_ELEM_AXIS                "axis"
 #define BUTTONMAP_XML_ELEM_BUTTON              "button"
 #define BUTTONMAP_XML_ELEM_CONTROLLER          "controller"

--- a/src/storage/xml/ButtonMapXml.cpp
+++ b/src/storage/xml/ButtonMapXml.cpp
@@ -420,6 +420,12 @@ bool CButtonMapXml::Deserialize(const TiXmlElement* pElement, FeatureVector& fea
       if (pUp || pDown || pRight || pLeft)
       {
         type = m_controllerHelper->FeatureType(controllerId, strName);
+
+        // The type may be unknown if the controller profile isn't installed.
+        // If the feature has multiple directions, 99.9% of the time it's an
+        // analog stick every time.
+        if (type == JOYSTICK_FEATURE_TYPE_UNKNOWN)
+          type = JOYSTICK_FEATURE_TYPE_ANALOG_STICK;
       }
       else
       {

--- a/src/storage/xml/ButtonMapXml.cpp
+++ b/src/storage/xml/ButtonMapXml.cpp
@@ -68,10 +68,7 @@ bool CButtonMapXml::Load(void)
   const TiXmlElement* pController = pDevice->FirstChildElement(BUTTONMAP_XML_ELEM_CONTROLLER);
 
   if (!pController)
-  {
-    esyslog("Device \"%s\": can't find <%s> tag", m_device->Name().c_str(), BUTTONMAP_XML_ELEM_CONTROLLER);
-    return false;
-  }
+    dsyslog("Device \"%s\": can't find <%s> tag", m_device->Name().c_str(), BUTTONMAP_XML_ELEM_CONTROLLER);
 
   // For logging purposes
   unsigned int totalFeatureCount = 0;

--- a/src/storage/xml/DeviceXml.h
+++ b/src/storage/xml/DeviceXml.h
@@ -10,6 +10,8 @@
 
 #include "storage/StorageTypes.h"
 
+#include <string>
+
 class TiXmlElement;
 
 namespace JOYSTICK
@@ -28,6 +30,9 @@ namespace JOYSTICK
 
     static bool SerializeConfig(const CDeviceConfiguration& config, TiXmlElement* pElement);
     static bool DeserializeConfig(const TiXmlElement* pElement, CDeviceConfiguration& config);
+
+    static bool SerializeAppearance(const std::string& controllerId, TiXmlElement* pElement);
+    static bool DeserializeAppearance(const TiXmlElement* pElement, std::string& controllerId);
 
     static bool SerializeAxis(unsigned int index, const AxisConfiguration& axisConfig, TiXmlElement* pElement);
     static bool DeserializeAxis(const TiXmlElement* pElement, unsigned int& index, AxisConfiguration& axisConfig);


### PR DESCRIPTION
## Description

This PR supports the effort in https://github.com/xbmc/xbmc/pull/22856. Multiple controllers will now be shown as their known image in the UI.

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/22856.