### PR TITLE
close correctly the uninitialized joysticks

### DIFF
--- a/src/api/udev/JoystickInterfaceUdev.cpp
+++ b/src/api/udev/JoystickInterfaceUdev.cpp
@@ -92,8 +92,13 @@ bool CJoystickInterfaceUdev::ScanForJoysticks(JoystickVector& joysticks)
 
      if (devnode != nullptr)
      {
-       JoystickPtr joystick = JoystickPtr(new CJoystickUdev(dev, devnode));
-       joysticks.push_back(joystick);
+       CJoystickUdev *j = new CJoystickUdev(dev, devnode);
+       if(j->isInitialized()) {
+	 JoystickPtr joystick = JoystickPtr(j);
+	 joysticks.push_back(joystick);
+       } else {
+	 delete j;
+       }
      }
 
      udev_device_unref(dev);

--- a/src/api/udev/JoystickUdev.h
+++ b/src/api/udev/JoystickUdev.h
@@ -58,6 +58,7 @@ namespace JOYSTICK
     virtual bool Initialize(void) override;
     virtual void Deinitialize(void) override;
     virtual void ProcessEvents(void) override;
+    bool isInitialized() { return m_bInitialized; }
 
   protected:
     // implementation of CJoystick


### PR DESCRIPTION
without that closing, the number of open files is growing (can be observed via lsof | grep kodi | grep /dev) and ends to crash kodi after a long time