### PR TITLE
Re-enable Guide button on Windows 8/10

### DIFF
--- a/src/api/xinput/JoystickXInput.cpp
+++ b/src/api/xinput/JoystickXInput.cpp
@@ -55,13 +55,13 @@ bool CJoystickXInput::Equals(const CJoystick* rhs) const
 
 void CJoystickXInput::PowerOff()
 {
-  if (CXInputDLL::Get().Version() == "1.3")
+  if (CXInputDLL::Get().SupportsPowerOff())
     CXInputDLL::Get().PowerOff(m_controllerID);
 }
 
 bool CJoystickXInput::ScanEvents(void)
 {
-  if (CXInputDLL::Get().Version() == "1.3")
+  if (CXInputDLL::Get().HasGuideButton())
   {
     XINPUT_STATE_EX controllerState;
 

--- a/src/api/xinput/XInputDLL.cpp
+++ b/src/api/xinput/XInputDLL.cpp
@@ -113,12 +113,12 @@ void CXInputDLL::Unload(void)
 
 bool CXInputDLL::HasGuideButton(void) const
 {
-  return m_strVersion == "1.3";
+  return m_strVersion == "1.3" || m_strVersion == "1.4";
 }
 
 bool CXInputDLL::SupportsPowerOff(void) const
 {
-  return m_strVersion == "1.3";
+  return m_strVersion == "1.3" || m_strVersion == "1.4";
 }
 
 bool CXInputDLL::GetState(unsigned int controllerId, XINPUT_STATE& state)


### PR DESCRIPTION
## Description

This PR re-enables the Guide button on Windows 8/10. It was originally disabled in early 2017 in https://github.com/xbmc/peripheral.joystick/pull/79 due to the following crash reported by some users:

```
INVALID_POINTER_READ_DETOURS_c0000005_XInputUap.dll!XInputCore::XInputManager::_XInputManager
```

Now, we have some feature requests for the Guide button to return: https://forum.kodi.tv/showthread.php?tid=339917

So I figure we'll enable it for v21 and watch out for any crashes. If all goes well we can ship the Guide button in v21. If we hear more reports of crashes, we can look into other options.

## How has this been tested?

Included in latest 20.2 test builds: https://github.com/garbear/xbmc/releases

Tested on latest master. Guide button works, but only after disabling the following setting:

Start -> Settings -> Gaming  -> Xbox Game Bar

Disable "Open Xbox Game Bar using this button on a controller: X"

After that, the Guide button works in Kodi.

However, if Steam is open in the background, then it will be focused. Steam must be exited to not interfere with Kodi. There should be a way to fix this in Steam, however.