### PR TITLE
Revert "Re-enable Guide button on Windows 8/10"

### DIFF
--- a/src/api/xinput/XInputDLL.cpp
+++ b/src/api/xinput/XInputDLL.cpp
@@ -113,12 +113,12 @@ void CXInputDLL::Unload(void)
 
 bool CXInputDLL::HasGuideButton(void) const
 {
-  return m_strVersion == "1.3" || m_strVersion == "1.4";
+  return m_strVersion == "1.3";
 }
 
 bool CXInputDLL::SupportsPowerOff(void) const
 {
-  return m_strVersion == "1.3" || m_strVersion == "1.4";
+  return m_strVersion == "1.3";
 }
 
 bool CXInputDLL::GetState(unsigned int controllerId, XINPUT_STATE& state)


### PR DESCRIPTION
## Description

This mostly reverts #288. Apparently, not only was the guide button enabled for windows 8/10, but also for Xbox, which totally broke controller support, kinda a necessity.

Merging immediately to fix xbox.