### PR TITLE
Remove non-existing buttons from PS Gamepad

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad_11b_8a.xml
@@ -454,11 +454,9 @@
             <feature name="circle" button="1" />
             <feature name="cross" button="0" />
             <feature name="down" axis="+7" />
-            <feature name="l3" button="9" />
             <feature name="left" axis="-6" />
             <feature name="leftbumper" button="4" />
             <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="10" />
             <feature name="right" axis="+6" />
             <feature name="rightbumper" button="5" />
             <feature name="righttrigger" axis="+5" />


### PR DESCRIPTION
## Description

Corresponds to https://github.com/kodi-game/controller-topology-project/pull/275

Buttons no longer exist, so remove them from the "codex" buttonmap.