### PR TITLE
Re-enable guide button, but only on Windows Desktop

### DIFF
--- a/src/api/xinput/XInputDLL.cpp
+++ b/src/api/xinput/XInputDLL.cpp
@@ -113,11 +113,21 @@ void CXInputDLL::Unload(void)
 
 bool CXInputDLL::HasGuideButton(void) const
 {
+#if defined(TARGET_WINDOWS_DESKTOP)
+  if (m_strVersion == "1.4")
+    return true;
+#endif
+
   return m_strVersion == "1.3";
 }
 
 bool CXInputDLL::SupportsPowerOff(void) const
 {
+#if defined(TARGET_WINDOWS_DESKTOP)
+  if (m_strVersion == "1.4")
+    return true;
+#endif
+
   return m_strVersion == "1.3";
 }
 


### PR DESCRIPTION
## Description

This PR is a replacement for https://github.com/xbmc/peripheral.joystick/pull/288, which only enables the Guide button on Windows desktop. The problem is that the guide button broke Xbox input, kinda important because a controller is absolutely needed. I hope to avoid the problem by only enabling the Guide button on the desktop version of Windows.

## How has this been tested?

Only tested on Windows Desktop. The guide button successfully works. Untested on Xbox.