### PR TITLE
Peripheral API v3.0.2: Stable peripheral locations

### DIFF
--- a/src/api/JoystickManager.h
+++ b/src/api/JoystickManager.h
@@ -13,6 +13,7 @@
 
 #include <kodi/addon-instance/peripheral/PeripheralUtils.h>
 
+#include <map>
 #include <mutex>
 #include <set>
 #include <vector>
@@ -150,6 +151,7 @@ namespace JOYSTICK
     std::set<IJoystickInterface*>    m_enabledInterfaces;
     JoystickVector                   m_joysticks;
     unsigned int                     m_nextJoystickIndex;
+    std::map<unsigned int, kodi::addon::Joystick> m_expiredJoysticks;
     bool                             m_bChanged;
     mutable std::recursive_mutex m_changedMutex;
     mutable std::recursive_mutex m_interfacesMutex;

--- a/src/api/linux/JoystickInterfaceLinux.cpp
+++ b/src/api/linux/JoystickInterfaceLinux.cpp
@@ -17,7 +17,6 @@
 #include <linux/input.h>
 #include <linux/joystick.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -87,13 +86,10 @@ bool CJoystickInterfaceLinux::ScanForJoysticks(JoystickVector& joysticks)
         continue;
       }
 
-      unsigned int index = (unsigned int)std::max(strtol(pDirent->d_name + strlen("js"), NULL, 10), 0L);
-
       JoystickPtr joystick = JoystickPtr(new CJoystickLinux(fd, filename));
       joystick->SetName(name);
       joystick->SetButtonCount(buttons);
       joystick->SetAxisCount(axes);
-      joystick->SetRequestedPort(index);
       joysticks.push_back(joystick);
     }
   }


### PR DESCRIPTION
## Description

This PR is the counterpart to https://github.com/xbmc/xbmc/pull/24392. It makes use of the new comparison operators to assign a stable peripheral index when a controller is unplugged/replugged.

However, if you have two identical controllers, and they are replugged in the opposite order, their locations will be swapped. This isn't too big of an issue, because if the controllers are identical the two players can simply swap them if needed.

An additional change is included for the Linux Joystick API driver. The comparison was breaking because replugging controllers in the wrong order assigns new `/dev/input/js#` filenames. As a result, the Linux driver instability would propagate to location instability.

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/24392.