### PR TITLE
Android buttonmaps

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/android/Lite-On_Technology_Corp._USB_Multimedia_Keyboard_v04CA_p0027_23b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Lite-On_Technology_Corp._USB_Multimedia_Keyboard_v04CA_p0027_23b.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Lite-On Technology Corp. USB Multimedia Keyboard" provider="android" vid="04CA" pid="0027" buttoncount="23">
+        <configuration>
+            <appearance id="game.controller.keyboard" />
+        </configuration>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Logitech_Gamepad_F310_v046D_pC21D_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Logitech_Gamepad_F310_v046D_pC21D_11b_8a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Logitech Gamepad F310" provider="android" vid="046D" pid="C21D" buttoncount="11" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="9" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="6" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="7" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="8" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Microsoft_Microsoft___Nano_Transceiver_v2.0_v045E_p0800_23b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Microsoft_Microsoft___Nano_Transceiver_v2.0_v045E_p0800_23b.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Microsoft Microsoft® Nano Transceiver v2.0" provider="android" vid="045E" pid="0800" buttoncount="23">
+        <configuration>
+            <appearance id="game.controller.keyboard" />
+        </configuration>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Microsoft_X-Box_One_pad__Firmware_2015__v045E_p02DD_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Microsoft_X-Box_One_pad__Firmware_2015__v045E_p02DD_11b_8a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Microsoft X-Box One pad (Firmware 2015)" provider="android" vid="045E" pid="02DD" buttoncount="11" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="9" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="6" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="7" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="8" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Microsoft_X-Box_One_pad__Firmware_2015__v045E_p02DD_23b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Microsoft_X-Box_One_pad__Firmware_2015__v045E_p02DD_23b_8a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Microsoft X-Box One pad (Firmware 2015)" provider="android" vid="045E" pid="02DD" buttoncount="23" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="12" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="16" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="13" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="17" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="3" />
+            <feature name="y" button="4" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.03_v0955_p7210_13b_10a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.03_v0955_p7210_13b_10a.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="NVIDIA Corporation NVIDIA Controller v01.03" provider="android" vid="0955" pid="7210" buttoncount="13" axiscount="10">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="down" axis="+9" />
+            <feature name="left" axis="-8" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="6" />
+            <feature name="lefttrigger" axis="+3" />
+            <feature name="right" axis="+8" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-5" />
+                <down axis="+5" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+            <feature name="rightthumb" button="7" />
+            <feature name="righttrigger" axis="+4" />
+            <feature name="up" axis="-9" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.03_v0955_p7210_23b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.03_v0955_p7210_23b_8a.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <buttonmap>
     <device name="NVIDIA Corporation NVIDIA Controller v01.03" provider="android" vid="0955" pid="7210" buttoncount="23" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
         <controller id="game.controller.default">
             <feature name="a" button="0" />
             <feature name="b" button="1" />

--- a/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.04_v0955_p7214_18b_10a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.04_v0955_p7214_18b_10a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="NVIDIA Corporation NVIDIA Controller v01.04" provider="android" vid="0955" pid="7214" buttoncount="18" axiscount="10">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="2" />
+            <feature name="b" button="3" />
+            <feature name="back" button="1" />
+            <feature name="down" axis="+9" />
+            <feature name="guide" button="10" />
+            <feature name="left" axis="-8" />
+            <feature name="leftbumper" button="6" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="8" />
+            <feature name="lefttrigger" axis="+3" />
+            <feature name="right" axis="+8" />
+            <feature name="rightbumper" button="7" />
+            <feature name="rightstick">
+                <up axis="-5" />
+                <down axis="+5" />
+                <right axis="+2" />
+                <left axis="-2" />
+            </feature>
+            <feature name="rightthumb" button="9" />
+            <feature name="righttrigger" axis="+4" />
+            <feature name="up" axis="-9" />
+            <feature name="x" button="4" />
+            <feature name="y" button="5" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.04_v0955_p7214_23b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.04_v0955_p7214_23b_8a.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" ?>
 <buttonmap>
     <device name="NVIDIA Corporation NVIDIA Controller v01.04" provider="android" vid="0955" pid="7214" buttoncount="23" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
         <controller id="game.controller.default">
             <feature name="a" button="0" />
             <feature name="b" button="1" />

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_13b_8a.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Sony Interactive Entertainment Wireless Controller" provider="android" vid="054C" pid="09CC" buttoncount="13" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.ps.dualanalog" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
+        <controller id="game.controller.ps.dualanalog">
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="8" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="r3" button="9" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" axis="+5" />
+            <feature name="select" button="11" />
+            <feature name="square" button="2" />
+            <feature name="start" button="10" />
+            <feature name="triangle" button="3" />
+            <feature name="up" axis="-7" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_23b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_23b_8a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Sony Interactive Entertainment Wireless Controller" provider="android" vid="054C" pid="09CC" buttoncount="23" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.ps.dualanalog" />
+        </configuration>
+        <controller id="game.controller.ps.dualanalog">
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="16" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="12" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" button="14" />
+            <feature name="r3" button="17" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="13" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" button="15" />
+            <feature name="select" button="6" />
+            <feature name="square" button="3" />
+            <feature name="start" button="11" />
+            <feature name="triangle" button="4" />
+            <feature name="up" axis="-7" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Wireless_Controller_v054C_p09CC_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Wireless_Controller_v054C_p09CC_13b_8a.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Wireless Controller" provider="android" vid="054C" pid="09CC" buttoncount="13" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.ps.dualanalog" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
+        <controller id="game.controller.ps.dualanalog">
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="8" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="r3" button="9" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" axis="+5" />
+            <feature name="select" button="11" />
+            <feature name="square" button="2" />
+            <feature name="start" button="10" />
+            <feature name="triangle" button="3" />
+            <feature name="up" axis="-7" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Wireless_Controller_v054C_p09CC_23b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Wireless_Controller_v054C_p09CC_23b_8a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Wireless Controller" provider="android" vid="054C" pid="09CC" buttoncount="23" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.ps.dualanalog" />
+        </configuration>
+        <controller id="game.controller.ps.dualanalog">
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="16" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="12" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" button="14" />
+            <feature name="r3" button="17" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="13" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" button="15" />
+            <feature name="select" button="6" />
+            <feature name="square" button="3" />
+            <feature name="start" button="11" />
+            <feature name="triangle" button="4" />
+            <feature name="up" axis="-7" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Xbox_360_Wireless_Receiver__XBOX__v045E_p02A1_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Xbox_360_Wireless_Receiver__XBOX__v045E_p02A1_11b_8a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Xbox 360 Wireless Receiver (XBOX)" provider="android" vid="045E" pid="02A1" buttoncount="11" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="9" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="6" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="7" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="8" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Xbox_360_Wireless_Receiver__XBOX__v045E_p02A1_23b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Xbox_360_Wireless_Receiver__XBOX__v045E_p02A1_23b_8a.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Xbox 360 Wireless Receiver (XBOX)" provider="android" vid="045E" pid="02A1" buttoncount="23" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="12" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="16" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="13" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="17" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="11" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="3" />
+            <feature name="y" button="4" />
+        </controller>
+    </device>
+</buttonmap>


### PR DESCRIPTION
## Description

This PR reverts the removal of the Android buttonmaps in https://github.com/xbmc/peripheral.joystick/pull/295, and then adds buttonmaps for the new button ID format introduced in https://github.com/xbmc/xbmc/pull/24604.

## How has this been tested?

Tested as part of https://github.com/xbmc/xbmc/pull/24604.