### PR TITLE
Nexus backports

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/linux/DualSense_Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/DualSense_Wireless_Controller_13b_8a.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="DualSense Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.ps.dualanalog" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
+        <controller id="game.controller.ps.dualanalog">
+            <feature name="analog" button="10" />
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="11" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="r3" button="12" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" axis="+5" />
+            <feature name="select" button="8" />
+            <feature name="square" button="3" />
+            <feature name="start" button="9" />
+            <feature name="triangle" button="2" />
+            <feature name="up" axis="-7" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Gamepad_F310_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Gamepad_F310_11b_8a.xml
@@ -2,6 +2,7 @@
 <buttonmap>
     <device name="Logitech Gamepad F310" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
+            <appearance id="game.controller.default" />
             <axis index="2" center="-1" range="2" />
             <axis index="5" center="-1" range="2" />
         </configuration>
@@ -10,6 +11,7 @@
             <feature name="b" button="1" />
             <feature name="back" button="6" />
             <feature name="down" axis="+7" />
+            <feature name="guide" button="8" />
             <feature name="left" axis="-6" />
             <feature name="leftbumper" button="4" />
             <feature name="leftstick">

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_DualSense_Wireless__13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_DualSense_Wireless__13b_8a.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Sony Interactive Entertainment DualSense Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.ps.dualanalog" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
+        <controller id="game.controller.ps.dualanalog">
+            <feature name="analog" button="10" />
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="11" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="r3" button="12" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" axis="+5" />
+            <feature name="select" button="8" />
+            <feature name="square" button="3" />
+            <feature name="start" button="9" />
+            <feature name="triangle" button="2" />
+            <feature name="up" axis="-7" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver__XBOX__15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver__XBOX__15b_8a.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Xbox 360 Wireless Receiver (XBOX)" provider="linux" buttoncount="15" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" button="14" />
+            <feature name="guide" button="8" />
+            <feature name="left" button="11" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="9" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" button="12" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="10" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="7" />
+            <feature name="up" button="13" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/DualSense_Wireless_Controller_v054C_p0CE6_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/DualSense_Wireless_Controller_v054C_p0CE6_13b_8a.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="DualSense Wireless Controller" provider="udev" vid="054C" pid="0CE6" buttoncount="13" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.ps.dualanalog" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
+        <controller id="game.controller.ps.dualanalog">
+            <feature name="analog" button="10" />
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="11" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="r3" button="12" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" axis="+5" />
+            <feature name="select" button="8" />
+            <feature name="square" button="3" />
+            <feature name="start" button="9" />
+            <feature name="triangle" button="2" />
+            <feature name="up" axis="-7" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Logitech_Gamepad_F310_v046D_pC21D_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Logitech_Gamepad_F310_v046D_pC21D_11b_8a.xml
@@ -3,6 +3,8 @@
     <device name="Logitech Gamepad F310" provider="udev" vid="046D" pid="C21D" buttoncount="11" axiscount="8">
         <configuration>
             <appearance id="game.controller.default" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
         </configuration>
         <controller id="game.controller.default">
             <feature name="a" button="0" />

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_0_v28DE_p11FF_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_0_v28DE_p11FF_11b_8a.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Microsoft X-Box 360 pad 0" provider="udev" vid="28DE" pid="11FF" buttoncount="11" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" axis="+7" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="9" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="10" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="7" />
+            <feature name="up" axis="-7" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_DualSense_Wireless__v054C_p0CE6_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_DualSense_Wireless__v054C_p0CE6_13b_8a.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Sony Interactive Entertainment DualSense Wireless Controller" provider="udev" vid="054C" pid="0CE6" buttoncount="13" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.ps.dualanalog" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
+        </configuration>
+        <controller id="game.controller.ps.dualanalog">
+            <feature name="analog" button="10" />
+            <feature name="circle" button="1" />
+            <feature name="cross" button="0" />
+            <feature name="down" axis="+7" />
+            <feature name="l3" button="11" />
+            <feature name="left" axis="-6" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="r3" button="12" />
+            <feature name="right" axis="+6" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" axis="+5" />
+            <feature name="select" button="8" />
+            <feature name="square" button="3" />
+            <feature name="start" button="9" />
+            <feature name="triangle" button="2" />
+            <feature name="up" axis="-7" />
+        </controller>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_13b_8a.xml
@@ -3,6 +3,10 @@
     <device name="Sony Interactive Entertainment Wireless Controller" provider="udev" vid="054C" pid="09CC" buttoncount="13" axiscount="8">
         <configuration>
             <appearance id="game.controller.ps.dualanalog" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+            <button index="6" ignore="true" />
+            <button index="7" ignore="true" />
         </configuration>
         <controller id="game.controller.ps.dualanalog">
             <feature name="analog" button="10" />
@@ -12,11 +16,23 @@
             <feature name="l3" button="11" />
             <feature name="left" axis="-6" />
             <feature name="leftbumper" button="4" />
-            <feature name="lefttrigger" button="6" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="lefttrigger" axis="+2" />
             <feature name="r3" button="12" />
             <feature name="right" axis="+6" />
             <feature name="rightbumper" button="5" />
-            <feature name="righttrigger" button="7" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="righttrigger" axis="+5" />
             <feature name="select" button="8" />
             <feature name="square" button="3" />
             <feature name="start" button="9" />

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_360_Wireless_Receiver__XBOX__v045E_p02A1_15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_360_Wireless_Receiver__XBOX__v045E_p02A1_15b_8a.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="Xbox 360 Wireless Receiver (XBOX)" provider="udev" vid="045E" pid="02A1" buttoncount="15" axiscount="8">
+        <configuration>
+            <appearance id="game.controller.default" />
+            <axis index="2" center="-1" range="2" />
+            <axis index="5" center="-1" range="2" />
+        </configuration>
+        <controller id="game.controller.default">
+            <feature name="a" button="0" />
+            <feature name="b" button="1" />
+            <feature name="back" button="6" />
+            <feature name="down" button="14" />
+            <feature name="guide" button="8" />
+            <feature name="left" button="11" />
+            <feature name="leftbumper" button="4" />
+            <feature name="leftstick">
+                <up axis="-1" />
+                <down axis="+1" />
+                <right axis="+0" />
+                <left axis="-0" />
+            </feature>
+            <feature name="leftthumb" button="9" />
+            <feature name="lefttrigger" axis="+2" />
+            <feature name="right" button="12" />
+            <feature name="rightbumper" button="5" />
+            <feature name="rightstick">
+                <up axis="-4" />
+                <down axis="+4" />
+                <right axis="+3" />
+                <left axis="-3" />
+            </feature>
+            <feature name="rightthumb" button="10" />
+            <feature name="righttrigger" axis="+5" />
+            <feature name="start" button="7" />
+            <feature name="up" button="13" />
+            <feature name="x" button="2" />
+            <feature name="y" button="3" />
+        </controller>
+    </device>
+</buttonmap>

--- a/src/api/udev/JoystickInterfaceUdev.cpp
+++ b/src/api/udev/JoystickInterfaceUdev.cpp
@@ -86,17 +86,17 @@ bool CJoystickInterfaceUdev::ScanForJoysticks(JoystickVector& joysticks)
   struct udev_list_entry* devs = udev_enumerate_get_list_entry(enumerate);
   for (struct udev_list_entry* item = devs; item != nullptr; item = udev_list_entry_get_next(item))
   {
-     const char*         name = udev_list_entry_get_name(item);
-     struct udev_device* dev = udev_device_new_from_syspath(m_udev, name);
-     const char*         devnode = udev_device_get_devnode(dev);
+    const char* name = udev_list_entry_get_name(item);
+    struct udev_device* dev = udev_device_new_from_syspath(m_udev, name);
+    const char*  devnode = udev_device_get_devnode(dev);
 
-     if (devnode != nullptr)
-     {
-       JoystickPtr joystick = JoystickPtr(new CJoystickUdev(dev, devnode));
-       joysticks.push_back(joystick);
-     }
+    if (devnode != nullptr)
+    {
+      JoystickPtr joystick = JoystickPtr(new CJoystickUdev(dev, devnode));
+      joysticks.push_back(joystick);
+    }
 
-     udev_device_unref(dev);
+    udev_device_unref(dev);
   }
 
   udev_enumerate_unref(enumerate);

--- a/src/api/udev/JoystickInterfaceUdev.cpp
+++ b/src/api/udev/JoystickInterfaceUdev.cpp
@@ -9,6 +9,7 @@
 #include "JoystickInterfaceUdev.h"
 #include "JoystickUdev.h"
 #include "api/JoystickTypes.h"
+#include "log/Log.h"
 
 #include <libudev.h>
 #include <utility>
@@ -41,14 +42,21 @@ bool CJoystickInterfaceUdev::Initialize()
 {
   m_udev = udev_new();
   if (!m_udev)
+  {
+    esyslog("Failed to initialize udev");
     return false;
+  }
 
   m_udev_mon = udev_monitor_new_from_netlink(m_udev, "udev");
-  if (m_udev_mon)
+  if (!m_udev_mon)
   {
-     udev_monitor_filter_add_match_subsystem_devtype(m_udev_mon, "input", nullptr);
-     udev_monitor_enable_receiving(m_udev_mon);
+    esyslog("Failed to create udev monitor");
+    udev_unref(m_udev);
+    return false;
   }
+
+  udev_monitor_filter_add_match_subsystem_devtype(m_udev_mon, "input", nullptr);
+  udev_monitor_enable_receiving(m_udev_mon);
 
   return true;
 }

--- a/src/api/udev/JoystickInterfaceUdev.cpp
+++ b/src/api/udev/JoystickInterfaceUdev.cpp
@@ -92,8 +92,9 @@ bool CJoystickInterfaceUdev::ScanForJoysticks(JoystickVector& joysticks)
 
     if (devnode != nullptr)
     {
-      JoystickPtr joystick = JoystickPtr(new CJoystickUdev(dev, devnode));
-      joysticks.push_back(joystick);
+      std::shared_ptr<CJoystickUdev>joystick = std::make_shared<CJoystickUdev>(dev, devnode);
+      if (joystick->IsInitialized())
+        joysticks.emplace_back(std::move(joystick));
     }
 
     udev_device_unref(dev);

--- a/src/api/udev/JoystickUdev.cpp
+++ b/src/api/udev/JoystickUdev.cpp
@@ -286,11 +286,9 @@ bool CJoystickUdev::GetProperties()
   {
     std::sprintf(val, "%x", id[ID_VENDOR]);
     SetVendorID(strtol(val, NULL, 16));
-    dsyslog("[udev] Joystick information vendorid=%s for %s", val, m_path.c_str());
 
     std::sprintf(val, "%x", id[ID_PRODUCT]);
     SetProductID(strtol(val, NULL, 16));
-    dsyslog("[udev] Joystick information productid=%s for %s", val, m_path.c_str());
   }
 
   struct stat st;

--- a/src/api/udev/JoystickUdev.cpp
+++ b/src/api/udev/JoystickUdev.cpp
@@ -303,12 +303,7 @@ bool CJoystickUdev::GetProperties()
   // Go through all possible keycodes, check if they are used, and map them to
   // button/axes/hat indices
   unsigned int buttons = 0;
-  for (unsigned int i = KEY_UP; i <= KEY_DOWN; i++)
-  {
-    if (test_bit(i, keybit))
-      m_button_bind[i] = buttons++;
-  }
-  for (unsigned int i = BTN_MISC; i < KEY_MAX; i++)
+  for (unsigned int i = 0; i < KEY_MAX; i++)
   {
     if (test_bit(i, keybit))
       m_button_bind[i] = buttons++;

--- a/src/api/udev/JoystickUdev.cpp
+++ b/src/api/udev/JoystickUdev.cpp
@@ -217,10 +217,13 @@ bool CJoystickUdev::ScanEvents(void)
               const unsigned int axisIndex = it->second.axisIndex;
               const input_absinfo& info = it->second.axisInfo;
 
-              if (event.value >= 0)
-                SetAxisValue(axisIndex, event.value, info.maximum);
+              int middle = (info.minimum + info.maximum) / 2;
+              int length = (info.maximum - info.minimum) / 2;
+
+              if (std::abs(event.value - middle) > length / 2)
+                SetAxisValue(axisIndex, event.value - middle, length);
               else
-                SetAxisValue(axisIndex, event.value, -info.minimum);
+                SetAxisValue(axisIndex, 0, length);
             }
           }
           break;

--- a/src/api/udev/JoystickUdev.h
+++ b/src/api/udev/JoystickUdev.h
@@ -59,6 +59,9 @@ namespace JOYSTICK
     virtual void Deinitialize(void) override;
     virtual void ProcessEvents(void) override;
 
+    // udev API
+    bool IsInitialized() const { return m_bInitialized; }
+
   protected:
     // implementation of CJoystick
     virtual bool ScanEvents(void) override;


### PR DESCRIPTION
## Description

This PR backports the following PRs to Nexus:

* https://github.com/xbmc/peripheral.joystick/pull/251
* https://github.com/xbmc/peripheral.joystick/pull/274
* https://github.com/xbmc/peripheral.joystick/pull/275
* https://github.com/xbmc/peripheral.joystick/pull/276
* https://github.com/xbmc/peripheral.joystick/pull/309

## Motivation and context

I wasn't going to backport the udev fixes, because they could break stuff for Nexus users, but udev isn't the main driver, and outside of Batocera I've never come across someone using the udev driver. And Batocera already uses these patches. So no worry about backporting.