### PR TITLE
Fix serializing empty configuration

### DIFF
--- a/src/storage/xml/DeviceXml.cpp
+++ b/src/storage/xml/DeviceXml.cpp
@@ -103,32 +103,29 @@ bool CDeviceXml::Deserialize(const TiXmlElement* pElement, CDevice& record)
 
 bool CDeviceXml::SerializeConfig(const CDeviceConfiguration& config, TiXmlElement* pElement)
 {
-  if (!config.IsEmpty())
+  TiXmlElement configurationElement(BUTTONMAP_XML_ELEM_CONFIGURATION);
+  TiXmlNode* configurationNode = pElement->InsertEndChild(configurationElement);
+  if (configurationNode == nullptr)
+    return false;
+
+  TiXmlElement* configurationElem = configurationNode->ToElement();
+  if (configurationElem == nullptr)
+    return false;
+
+  const std::string controllerId = config.GetAppearance();
+  if (!SerializeAppearance(controllerId, configurationElem))
+    return false;
+
+  for (const auto& axis : config.Axes())
   {
-    TiXmlElement configurationElement(BUTTONMAP_XML_ELEM_CONFIGURATION);
-    TiXmlNode* configurationNode = pElement->InsertEndChild(configurationElement);
-    if (configurationNode == nullptr)
+    if (!SerializeAxis(axis.first, axis.second, configurationElem))
       return false;
+  }
 
-    TiXmlElement* configurationElem = configurationNode->ToElement();
-    if (configurationElem == nullptr)
+  for (const auto& button : config.Buttons())
+  {
+    if (!SerializeButton(button.first, button.second, configurationElem))
       return false;
-
-    const std::string controllerId = config.GetAppearance();
-    if (!SerializeAppearance(controllerId, configurationElem))
-      return false;
-
-    for (const auto& axis : config.Axes())
-    {
-      if (!SerializeAxis(axis.first, axis.second, configurationElem))
-        return false;
-    }
-
-    for (const auto& button : config.Buttons())
-    {
-      if (!SerializeButton(button.first, button.second, configurationElem))
-        return false;
-    }
   }
 
   return true;


### PR DESCRIPTION
## Description

This PR ensures that if the buttonmap currently has data, but then all data is reset, then the newly-reset state is still written to the file.

View change without whitespace: https://github.com/xbmc/peripheral.joystick/commit/bb3a35c577643f43ba824cc1793fe641a1160558?w=1

This change is only needed with https://github.com/xbmc/xbmc/pull/26286, which fixes the "Defaults" button in the Peripherals Dialog so that it resets controller appearance (aka sets appearance controller ID to "").

## How has this been tested?

Tested on my macbook M2 in coordination with https://github.com/xbmc/xbmc/pull/26286

### Before

Set joystick appearance to game.controller.mouse. Resetting the peripheral settings didn't write to the XML:

```xml
<?xml version="1.0" ?>
<buttonmap>
    <device name="Extended Gamepad" provider="GCController" buttoncount="16" axiscount="4">
        <configuration>
            <appearance id="game.controller.mouse" />
        </configuration>
    </device>
</buttonmap>
```

### After

Resetting peripheral settings correctly clear the appearance:


```xml
<?xml version="1.0" ?>
<buttonmap>
    <device name="Extended Gamepad" provider="GCController" buttoncount="16" axiscount="4">
        <configuration />
    </device>
</buttonmap>
```