### PR TITLE
[Omega] Remove virtual remotes for Shield TV

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/android/shield-ask-remote_v18D1_p0100_12b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/shield-ask-remote_v18D1_p0100_12b.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" ?>
-<buttonmap>
-    <device name="shield-ask-remote" provider="android" vid="18D1" pid="0100" buttoncount="12">
-        <configuration>
-            <appearance id="game.controller.remote" />
-        </configuration>
-    </device>
-</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/virtual-search_v18D1_p0100_12b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/virtual-search_v18D1_p0100_12b.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" ?>
-<buttonmap>
-    <device name="virtual-search" provider="android" vid="18D1" pid="0100" buttoncount="12">
-        <configuration>
-            <appearance id="game.controller.remote" />
-        </configuration>
-    </device>
-</buttonmap>


### PR DESCRIPTION
## Description

This removes the "appearances" for virtual remotes in the Omega branch.

![Screenshot_20250203-201505](https://github.com/user-attachments/assets/3fb34470-2e14-42e1-8c13-d416f7d5fc8e)

The buttonmaps here were added about 3 weeks ago in my last round of buttonmap updates.

## Motivation and context

On my Shield TV, I saw Kodi crash on startup on a new install (subsequent loads all succeeded).

I added images for the Shield TV virtual devices with some XML, figuring that it couldn't hurt stability. But Kodi applies the XML on startup, which could trigger a GUI response, possibly causing the crash (though unconfirmed).

So, I'm reverting these appearances for Omega just to be safe.