### PR TITLE
[Omega] Re-add virtual remotes for Shield TV

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/android/shield-ask-remote_v18D1_p0100_12b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/shield-ask-remote_v18D1_p0100_12b.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="shield-ask-remote" provider="android" vid="18D1" pid="0100" buttoncount="12">
+        <configuration>
+            <appearance id="game.controller.remote" />
+        </configuration>
+    </device>
+</buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/virtual-search_v18D1_p0100_12b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/virtual-search_v18D1_p0100_12b.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<buttonmap>
+    <device name="virtual-search" provider="android" vid="18D1" pid="0100" buttoncount="12">
+        <configuration>
+            <appearance id="game.controller.remote" />
+        </configuration>
+    </device>
+</buttonmap>


### PR DESCRIPTION
## Description

Revert of https://github.com/xbmc/peripheral.joystick/pull/324, which removed these Android buttonmaps.

The next time this add-on goes out on Android, it'll have the fix for the race condition (https://github.com/xbmc/xbmc/pull/26387) so it's safe to add these buttonmaps again once the race condition PR is merged.

## How has this been tested?

Setting breakpoints and verifying the race condition is fixed.