### PR TITLE
[CI] Build Azure for all platforms (Win32/Win64/ARM64)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,10 @@ jobs:
           GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: x64
           CONFIGURATION: Release
+        ARM64:
+          GENERATOR: "Visual Studio 17 2022"
+          ARCHITECTURE: ARM64
+          CONFIGURATION: Release
         Win32-UWP:
           GENERATOR: "Visual Studio 17 2022"
           ARCHITECTURE: Win32
@@ -39,16 +43,11 @@ jobs:
           ARCHITECTURE: x64
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
-        ARM32-UWP:
+        ARM64-UWP:
           GENERATOR: "Visual Studio 17 2022"
-          ARCHITECTURE: ARM
+          ARCHITECTURE: ARM64
           CONFIGURATION: Release
           WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
-        #ARM64-UWP:
-        #  GENERATOR: "Visual Studio 17 2022"
-        #  ARCHITECTURE: ARM64
-        #  CONFIGURATION: Release
-        #  WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.17763.0"
 
     workspace:
       clean: all


### PR DESCRIPTION
## Description

As title says, this runs the Azure pipeline for Win32/Win64/ARM64.

ARM32 is no longer supported by the Windows SDK.

## How as this been tested?

See CI results.