### PR TITLE
Fix loading XML files after tinyxml2 port

### DIFF
--- a/src/storage/xml/ButtonMapXml.cpp
+++ b/src/storage/xml/ButtonMapXml.cpp
@@ -46,7 +46,7 @@ bool CButtonMapXml::Load(void)
   }
 
   tinyxml2::XMLElement* pRootElement = xmlFile.RootElement();
-  if (!pRootElement || pRootElement->NoChildren() || pRootElement->Value() != BUTTONMAP_XML_ROOT)
+  if (!pRootElement || pRootElement->NoChildren() || std::string(pRootElement->Value()) != BUTTONMAP_XML_ROOT)
   {
     esyslog("Can't find root <%s> tag", BUTTONMAP_XML_ROOT);
     return false;

--- a/src/storage/xml/JoystickFamiliesXml.cpp
+++ b/src/storage/xml/JoystickFamiliesXml.cpp
@@ -26,7 +26,7 @@ bool CJoystickFamiliesXml::LoadFamilies(const std::string& path, JoystickFamilyM
   }
 
   tinyxml2::XMLElement* pRootElement = xmlFile.RootElement();
-  if (!pRootElement || pRootElement->NoChildren() || pRootElement->Value() != JOYSTICK_FAMILIES_XML_ELEM_FAMILIES)
+  if (!pRootElement || pRootElement->NoChildren() || std::string(pRootElement->Value()) != JOYSTICK_FAMILIES_XML_ELEM_FAMILIES)
   {
     esyslog("Can't find root <%s> tag", JOYSTICK_FAMILIES_XML_ELEM_FAMILIES);
     return false;


### PR DESCRIPTION
## Description

Fixes char* comparisons after https://github.com/xbmc/peripheral.joystick/pull/333.

## How has this been tested?

Build succeeds. Unable to runtime test, but it looks right.

EDIT: Runtime tested, looks good.