### PR TITLE
Normalize buttonmaps for tinyxml2

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_13b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_13b_4a.xml
@@ -1,31 +1,31 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Extended Gamepad" provider="GCController" buttoncount="13" axiscount="4">
         <controller id="game.controller.default">
-            <feature name="up" button="0" />
-            <feature name="down" button="1" />
-            <feature name="left" button="2" />
-            <feature name="right" button="3" />
-            <feature name="a" button="4" />
-            <feature name="b" button="5" />
-            <feature name="x" button="6" />
-            <feature name="y" button="7" />
-            <feature name="leftbumper" button="8" />
-            <feature name="lefttrigger" button="9" />
-            <feature name="rightbumper" button="10" />
-            <feature name="righttrigger" button="11" />
-            <feature name="start" button="12" />
+            <feature name="up" button="0"/>
+            <feature name="down" button="1"/>
+            <feature name="left" button="2"/>
+            <feature name="right" button="3"/>
+            <feature name="a" button="4"/>
+            <feature name="b" button="5"/>
+            <feature name="x" button="6"/>
+            <feature name="y" button="7"/>
+            <feature name="leftbumper" button="8"/>
+            <feature name="lefttrigger" button="9"/>
+            <feature name="rightbumper" button="10"/>
+            <feature name="righttrigger" button="11"/>
+            <feature name="start" button="12"/>
             <feature name="leftstick">
-                <up axis="+1" />
-                <down axis="-1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="+1"/>
+                <down axis="-1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="rightstick">
-                <up axis="+3" />
-                <down axis="-3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="+3"/>
+                <down axis="-3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
         </controller>
     </device>

--- a/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_15b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_15b_4a.xml
@@ -1,33 +1,33 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Extended Gamepad" provider="GCController" buttoncount="15" axiscount="4">
         <controller id="game.controller.default">
-            <feature name="up" button="0" />
-            <feature name="down" button="1" />
-            <feature name="left" button="2" />
-            <feature name="right" button="3" />
-            <feature name="a" button="4" />
-            <feature name="b" button="5" />
-            <feature name="x" button="6" />
-            <feature name="y" button="7" />
-            <feature name="leftbumper" button="8" />
-            <feature name="lefttrigger" button="9" />
-            <feature name="rightbumper" button="10" />
-            <feature name="righttrigger" button="11" />
-            <feature name="start" button="12" />
-            <feature name="leftthumb" button="14" />
-            <feature name="rightthumb" button="15" />
+            <feature name="up" button="0"/>
+            <feature name="down" button="1"/>
+            <feature name="left" button="2"/>
+            <feature name="right" button="3"/>
+            <feature name="a" button="4"/>
+            <feature name="b" button="5"/>
+            <feature name="x" button="6"/>
+            <feature name="y" button="7"/>
+            <feature name="leftbumper" button="8"/>
+            <feature name="lefttrigger" button="9"/>
+            <feature name="rightbumper" button="10"/>
+            <feature name="righttrigger" button="11"/>
+            <feature name="start" button="12"/>
+            <feature name="leftthumb" button="14"/>
+            <feature name="rightthumb" button="15"/>
             <feature name="leftstick">
-                <up axis="+1" />
-                <down axis="-1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="+1"/>
+                <down axis="-1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="rightstick">
-                <up axis="+3" />
-                <down axis="-3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="+3"/>
+                <down axis="-3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
         </controller>
     </device>

--- a/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/GCController/Extended_Gamepad_16b_4a.xml
@@ -1,34 +1,34 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Extended Gamepad" provider="GCController" buttoncount="16" axiscount="4">
         <controller id="game.controller.default">
-            <feature name="up" button="0" />
-            <feature name="down" button="1" />
-            <feature name="left" button="2" />
-            <feature name="right" button="3" />
-            <feature name="a" button="4" />
-            <feature name="b" button="5" />
-            <feature name="x" button="6" />
-            <feature name="y" button="7" />
-            <feature name="leftbumper" button="8" />
-            <feature name="lefttrigger" button="9" />
-            <feature name="rightbumper" button="10" />
-            <feature name="righttrigger" button="11" />
-            <feature name="start" button="12" />
-            <feature name="back" button="13" />
-            <feature name="leftthumb" button="14" />
-            <feature name="rightthumb" button="15" />
+            <feature name="up" button="0"/>
+            <feature name="down" button="1"/>
+            <feature name="left" button="2"/>
+            <feature name="right" button="3"/>
+            <feature name="a" button="4"/>
+            <feature name="b" button="5"/>
+            <feature name="x" button="6"/>
+            <feature name="y" button="7"/>
+            <feature name="leftbumper" button="8"/>
+            <feature name="lefttrigger" button="9"/>
+            <feature name="rightbumper" button="10"/>
+            <feature name="righttrigger" button="11"/>
+            <feature name="start" button="12"/>
+            <feature name="back" button="13"/>
+            <feature name="leftthumb" button="14"/>
+            <feature name="rightthumb" button="15"/>
             <feature name="leftstick">
-                <up axis="+1" />
-                <down axis="-1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="+1"/>
+                <down axis="-1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="rightstick">
-                <up axis="+3" />
-                <down axis="-3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="+3"/>
+                <down axis="-3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
         </controller>
     </device>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/7039RG_v1949_p0402_14b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/7039RG_v1949_p0402_14b_8a.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
   <device name="7039RG" provider="android" vid="1949" pid="0402" buttoncount="14" axiscount="8">
     <configuration>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Hi_keyboard_v0001_p0001_23b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Hi_keyboard_v0001_p0001_23b.xml
@@ -1,13 +1,13 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Hi keyboard" provider="android" vid="0001" pid="0001" buttoncount="23">
         <controller id="game.controller.default">
-            <feature name="a" button="22" />
-            <feature name="b" button="6" />
-            <feature name="down" button="20" />
-            <feature name="left" button="21" />
-            <feature name="right" button="19" />
-            <feature name="up" button="18" />
+            <feature name="a" button="22"/>
+            <feature name="b" button="6"/>
+            <feature name="down" button="20"/>
+            <feature name="left" button="21"/>
+            <feature name="right" button="19"/>
+            <feature name="up" button="18"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Microsoft_Microsoft___Nano_Transceiver_v2.0_v045E_p0800_9b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Microsoft_Microsoft___Nano_Transceiver_v2.0_v045E_p0800_9b_2a.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft Microsoft® Nano Transceiver v2.0" provider="android" vid="045E" pid="0800" buttoncount="9" axiscount="2">
         <configuration>
-            <appearance id="game.controller.keyboard" />
+            <appearance id="game.controller.keyboard"/>
         </configuration>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.03_v0955_p7210_23b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.03_v0955_p7210_23b_8a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="NVIDIA Corporation NVIDIA Controller v01.03" provider="android" vid="0955" pid="7210" buttoncount="23" axiscount="8">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="12" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="12"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="16" />
-            <feature name="lefttrigger" axis="+5" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="13" />
+            <feature name="leftthumb" button="16"/>
+            <feature name="lefttrigger" axis="+5"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="13"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="17" />
-            <feature name="righttrigger" axis="+4" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="rightthumb" button="17"/>
+            <feature name="righttrigger" axis="+4"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.04_v0955_p7214_23b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/NVIDIA_Corporation_NVIDIA_Controller_v01.04_v0955_p7214_23b_8a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="NVIDIA Corporation NVIDIA Controller v01.04" provider="android" vid="0955" pid="7214" buttoncount="23" axiscount="8">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="12" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="12"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="16" />
-            <feature name="lefttrigger" axis="+5" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="13" />
+            <feature name="leftthumb" button="16"/>
+            <feature name="lefttrigger" axis="+5"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="13"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="17" />
-            <feature name="righttrigger" axis="+4" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="rightthumb" button="17"/>
+            <feature name="righttrigger" axis="+4"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/OUYA_Game_Controller_v2836_p0001_23b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/OUYA_Game_Controller_v2836_p0001_23b_6a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="OUYA Game Controller" provider="android" vid="2836" pid="0001" buttoncount="23" axiscount="6">
         <configuration>
-            <appearance id="game.controller.ouya" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.ouya"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="3" />
-            <feature name="down" button="15" />
-            <feature name="left" button="9" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="3"/>
+            <feature name="down" button="15"/>
+            <feature name="left" button="9"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="12" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="11" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="12"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="11"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="13" />
-            <feature name="righttrigger" button="16" />
-            <feature name="start" button="17" />
-            <feature name="up" button="14" />
-            <feature name="x" button="1" />
-            <feature name="y" button="2" />
+            <feature name="rightthumb" button="13"/>
+            <feature name="righttrigger" button="16"/>
+            <feature name="start" button="17"/>
+            <feature name="up" button="14"/>
+            <feature name="x" button="1"/>
+            <feature name="y" button="2"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Xbox_360_Wireless_Receiver_v045E_p02A1_23b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Xbox_360_Wireless_Receiver_v045E_p02A1_23b_6a.xml
@@ -1,38 +1,38 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver" provider="android" vid="045E" pid="02A1" buttoncount="23" axiscount="6">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="20" />
-            <feature name="left" button="21" />
-            <feature name="leftbumper" button="12" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="20"/>
+            <feature name="left" button="21"/>
+            <feature name="leftbumper" button="12"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="16" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="19" />
-            <feature name="rightbumper" button="13" />
+            <feature name="leftthumb" button="16"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="19"/>
+            <feature name="rightbumper" button="13"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="17" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="11" />
-            <feature name="up" button="18" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="rightthumb" button="17"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="11"/>
+            <feature name="up" button="18"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/Xbox_360_Wireless_Receiver_v045E_p0719_23b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/Xbox_360_Wireless_Receiver_v045E_p0719_23b_6a.xml
@@ -1,38 +1,38 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver" provider="android" vid="045E" pid="0719" buttoncount="23" axiscount="6">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="20" />
-            <feature name="left" button="21" />
-            <feature name="leftbumper" button="12" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="20"/>
+            <feature name="left" button="21"/>
+            <feature name="leftbumper" button="12"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="16" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="19" />
-            <feature name="rightbumper" button="13" />
+            <feature name="leftthumb" button="16"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="19"/>
+            <feature name="rightbumper" button="13"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="17" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="11" />
-            <feature name="up" button="18" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="rightthumb" button="17"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="11"/>
+            <feature name="up" button="18"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/shield-ask-remote_v18D1_p0100_12b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/shield-ask-remote_v18D1_p0100_12b.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="shield-ask-remote" provider="android" vid="18D1" pid="0100" buttoncount="12">
         <configuration>
-            <appearance id="game.controller.remote" />
+            <appearance id="game.controller.remote"/>
         </configuration>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/virtual-remote_16b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/virtual-remote_16b.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="virtual-remote" provider="android" buttoncount="23">
         <controller id="game.controller.remote">
-            <feature name="back" button="6" />
+            <feature name="back" button="6"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/virtual-remote_23b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/virtual-remote_23b.xml
@@ -1,13 +1,13 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="virtual-remote" provider="android" buttoncount="23">
         <controller id="game.controller.default">
-            <feature name="a" button="22" />
-            <feature name="b" button="6" />
-            <feature name="down" button="20" />
-            <feature name="left" button="21" />
-            <feature name="right" button="19" />
-            <feature name="up" button="18" />
+            <feature name="a" button="22"/>
+            <feature name="b" button="6"/>
+            <feature name="down" button="20"/>
+            <feature name="left" button="21"/>
+            <feature name="right" button="19"/>
+            <feature name="up" button="18"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/android/virtual-search_v18D1_p0100_12b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/android/virtual-search_v18D1_p0100_12b.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="virtual-search" provider="android" vid="18D1" pid="0100" buttoncount="12">
         <configuration>
-            <appearance id="game.controller.remote" />
+            <appearance id="game.controller.remote"/>
         </configuration>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/application/Keyboard.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/application/Keyboard.xml
@@ -1,299 +1,299 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Keyboard" provider="application">
         <controller id="game.controller.amstrad.keyboard">
-            <feature name="0" key="0" />
-            <feature name="1" key="1" />
-            <feature name="2" key="2" />
-            <feature name="3" key="3" />
-            <feature name="4" key="4" />
-            <feature name="5" key="5" />
-            <feature name="6" key="6" />
-            <feature name="7" key="7" />
-            <feature name="8" key="8" />
-            <feature name="9" key="9" />
-            <feature name="a" key="a" />
-            <feature name="at" key="grave" />
-            <feature name="b" key="b" />
-            <feature name="backslash" key="backslash" />
-            <feature name="c" key="c" />
-            <feature name="capslock" key="capslock" />
-            <feature name="closebracket" key="rightbracket" />
-            <feature name="clr" key="delete" />
-            <feature name="colon" key="quote" />
-            <feature name="comma" key="comma" />
-            <feature name="control" key="leftctrl" />
-            <feature name="copy" key="leftalt" />
-            <feature name="d" key="d" />
-            <feature name="del" key="backspace" />
-            <feature name="dot" key="period" />
-            <feature name="down" key="down" />
-            <feature name="e" key="e" />
-            <feature name="esc" key="escape" />
-            <feature name="f" key="f" />
-            <feature name="f0" key="kp0" />
-            <feature name="f1" key="kp1" />
-            <feature name="f2" key="kp2" />
-            <feature name="f3" key="kp3" />
-            <feature name="f4" key="kp4" />
-            <feature name="f5" key="kp5" />
-            <feature name="f6" key="kp6" />
-            <feature name="f7" key="kp7" />
-            <feature name="f8" key="kp8" />
-            <feature name="f9" key="kp9" />
-            <feature name="fdot" key="kpperiod" />
-            <feature name="g" key="g" />
-            <feature name="gui" key="f10" />
-            <feature name="h" key="h" />
-            <feature name="hat" key="equals" />
-            <feature name="i" key="i" />
-            <feature name="intro" key="kpenter" />
-            <feature name="j" key="j" />
-            <feature name="k" key="k" />
-            <feature name="l" key="l" />
-            <feature name="left" key="left" />
-            <feature name="m" key="m" />
-            <feature name="minus" key="minus" />
-            <feature name="mousetoggle" key="insert" />
-            <feature name="n" key="n" />
-            <feature name="o" key="o" />
-            <feature name="openbracket" key="leftbracket" />
-            <feature name="p" key="p" />
-            <feature name="play" key="home" />
-            <feature name="q" key="q" />
-            <feature name="r" key="r" />
-            <feature name="return" key="enter" />
-            <feature name="rewind" key="pageup" />
-            <feature name="right" key="right" />
-            <feature name="s" key="s" />
-            <feature name="semicolon" key="semicolon" />
-            <feature name="shift" key="leftshift" />
-            <feature name="slash" key="slash" />
-            <feature name="space" key="space" />
-            <feature name="stop" key="end" />
-            <feature name="t" key="t" />
-            <feature name="tab" key="tab" />
-            <feature name="u" key="u" />
-            <feature name="up" key="up" />
-            <feature name="v" key="v" />
-            <feature name="vkbtoggle" key="f9" />
-            <feature name="w" key="w" />
-            <feature name="x" key="x" />
-            <feature name="y" key="y" />
-            <feature name="z" key="z" />
+            <feature name="0" key="0"/>
+            <feature name="1" key="1"/>
+            <feature name="2" key="2"/>
+            <feature name="3" key="3"/>
+            <feature name="4" key="4"/>
+            <feature name="5" key="5"/>
+            <feature name="6" key="6"/>
+            <feature name="7" key="7"/>
+            <feature name="8" key="8"/>
+            <feature name="9" key="9"/>
+            <feature name="a" key="a"/>
+            <feature name="at" key="grave"/>
+            <feature name="b" key="b"/>
+            <feature name="backslash" key="backslash"/>
+            <feature name="c" key="c"/>
+            <feature name="capslock" key="capslock"/>
+            <feature name="closebracket" key="rightbracket"/>
+            <feature name="clr" key="delete"/>
+            <feature name="colon" key="quote"/>
+            <feature name="comma" key="comma"/>
+            <feature name="control" key="leftctrl"/>
+            <feature name="copy" key="leftalt"/>
+            <feature name="d" key="d"/>
+            <feature name="del" key="backspace"/>
+            <feature name="dot" key="period"/>
+            <feature name="down" key="down"/>
+            <feature name="e" key="e"/>
+            <feature name="esc" key="escape"/>
+            <feature name="f" key="f"/>
+            <feature name="f0" key="kp0"/>
+            <feature name="f1" key="kp1"/>
+            <feature name="f2" key="kp2"/>
+            <feature name="f3" key="kp3"/>
+            <feature name="f4" key="kp4"/>
+            <feature name="f5" key="kp5"/>
+            <feature name="f6" key="kp6"/>
+            <feature name="f7" key="kp7"/>
+            <feature name="f8" key="kp8"/>
+            <feature name="f9" key="kp9"/>
+            <feature name="fdot" key="kpperiod"/>
+            <feature name="g" key="g"/>
+            <feature name="gui" key="f10"/>
+            <feature name="h" key="h"/>
+            <feature name="hat" key="equals"/>
+            <feature name="i" key="i"/>
+            <feature name="intro" key="kpenter"/>
+            <feature name="j" key="j"/>
+            <feature name="k" key="k"/>
+            <feature name="l" key="l"/>
+            <feature name="left" key="left"/>
+            <feature name="m" key="m"/>
+            <feature name="minus" key="minus"/>
+            <feature name="mousetoggle" key="insert"/>
+            <feature name="n" key="n"/>
+            <feature name="o" key="o"/>
+            <feature name="openbracket" key="leftbracket"/>
+            <feature name="p" key="p"/>
+            <feature name="play" key="home"/>
+            <feature name="q" key="q"/>
+            <feature name="r" key="r"/>
+            <feature name="return" key="enter"/>
+            <feature name="rewind" key="pageup"/>
+            <feature name="right" key="right"/>
+            <feature name="s" key="s"/>
+            <feature name="semicolon" key="semicolon"/>
+            <feature name="shift" key="leftshift"/>
+            <feature name="slash" key="slash"/>
+            <feature name="space" key="space"/>
+            <feature name="stop" key="end"/>
+            <feature name="t" key="t"/>
+            <feature name="tab" key="tab"/>
+            <feature name="u" key="u"/>
+            <feature name="up" key="up"/>
+            <feature name="v" key="v"/>
+            <feature name="vkbtoggle" key="f9"/>
+            <feature name="w" key="w"/>
+            <feature name="x" key="x"/>
+            <feature name="y" key="y"/>
+            <feature name="z" key="z"/>
         </controller>
         <controller id="game.controller.elektronika.bk">
-            <feature name="0" key="0" />
-            <feature name="1" key="1" />
-            <feature name="2" key="2" />
-            <feature name="3" key="3" />
-            <feature name="4" key="4" />
-            <feature name="5" key="5" />
-            <feature name="6" key="6" />
-            <feature name="7" key="7" />
-            <feature name="8" key="8" />
-            <feature name="9" key="9" />
-            <feature name="a" key="a" />
-            <feature name="b" key="b" />
-            <feature name="backslash" key="backslash" />
-            <feature name="backspace" key="backspace" />
-            <feature name="break" key="pause" />
-            <feature name="c" key="c" />
-            <feature name="comma" key="comma" />
-            <feature name="d" key="d" />
-            <feature name="down" key="down" />
-            <feature name="e" key="e" />
-            <feature name="enter" key="enter" />
-            <feature name="equals" key="equals" />
-            <feature name="escape" key="escape" />
-            <feature name="f" key="f" />
-            <feature name="f1" key="f1" />
-            <feature name="f10" key="f10" />
-            <feature name="f11" key="f11" />
-            <feature name="f12" key="f12" />
-            <feature name="f2" key="f2" />
-            <feature name="f3" key="f3" />
-            <feature name="f4" key="f4" />
-            <feature name="f5" key="f5" />
-            <feature name="f6" key="f6" />
-            <feature name="f7" key="f7" />
-            <feature name="f8" key="f8" />
-            <feature name="f9" key="f9" />
-            <feature name="g" key="g" />
-            <feature name="grave" key="grave" />
-            <feature name="h" key="h" />
-            <feature name="home" key="home" />
-            <feature name="i" key="i" />
-            <feature name="j" key="j" />
-            <feature name="k" key="k" />
-            <feature name="l" key="l" />
-            <feature name="left" key="left" />
-            <feature name="leftbracket" key="leftbracket" />
-            <feature name="m" key="m" />
-            <feature name="minus" key="minus" />
-            <feature name="n" key="n" />
-            <feature name="o" key="o" />
-            <feature name="p" key="p" />
-            <feature name="period" key="period" />
-            <feature name="q" key="q" />
-            <feature name="quote" key="quote" />
-            <feature name="r" key="r" />
-            <feature name="right" key="right" />
-            <feature name="rightbracket" key="rightbracket" />
-            <feature name="s" key="s" />
-            <feature name="semicolon" key="semicolon" />
-            <feature name="slash" key="slash" />
-            <feature name="space" key="space" />
-            <feature name="t" key="t" />
-            <feature name="tab" key="tab" />
-            <feature name="u" key="u" />
-            <feature name="up" key="up" />
-            <feature name="v" key="v" />
-            <feature name="w" key="w" />
-            <feature name="x" key="x" />
-            <feature name="y" key="y" />
-            <feature name="z" key="z" />
+            <feature name="0" key="0"/>
+            <feature name="1" key="1"/>
+            <feature name="2" key="2"/>
+            <feature name="3" key="3"/>
+            <feature name="4" key="4"/>
+            <feature name="5" key="5"/>
+            <feature name="6" key="6"/>
+            <feature name="7" key="7"/>
+            <feature name="8" key="8"/>
+            <feature name="9" key="9"/>
+            <feature name="a" key="a"/>
+            <feature name="b" key="b"/>
+            <feature name="backslash" key="backslash"/>
+            <feature name="backspace" key="backspace"/>
+            <feature name="break" key="pause"/>
+            <feature name="c" key="c"/>
+            <feature name="comma" key="comma"/>
+            <feature name="d" key="d"/>
+            <feature name="down" key="down"/>
+            <feature name="e" key="e"/>
+            <feature name="enter" key="enter"/>
+            <feature name="equals" key="equals"/>
+            <feature name="escape" key="escape"/>
+            <feature name="f" key="f"/>
+            <feature name="f1" key="f1"/>
+            <feature name="f10" key="f10"/>
+            <feature name="f11" key="f11"/>
+            <feature name="f12" key="f12"/>
+            <feature name="f2" key="f2"/>
+            <feature name="f3" key="f3"/>
+            <feature name="f4" key="f4"/>
+            <feature name="f5" key="f5"/>
+            <feature name="f6" key="f6"/>
+            <feature name="f7" key="f7"/>
+            <feature name="f8" key="f8"/>
+            <feature name="f9" key="f9"/>
+            <feature name="g" key="g"/>
+            <feature name="grave" key="grave"/>
+            <feature name="h" key="h"/>
+            <feature name="home" key="home"/>
+            <feature name="i" key="i"/>
+            <feature name="j" key="j"/>
+            <feature name="k" key="k"/>
+            <feature name="l" key="l"/>
+            <feature name="left" key="left"/>
+            <feature name="leftbracket" key="leftbracket"/>
+            <feature name="m" key="m"/>
+            <feature name="minus" key="minus"/>
+            <feature name="n" key="n"/>
+            <feature name="o" key="o"/>
+            <feature name="p" key="p"/>
+            <feature name="period" key="period"/>
+            <feature name="q" key="q"/>
+            <feature name="quote" key="quote"/>
+            <feature name="r" key="r"/>
+            <feature name="right" key="right"/>
+            <feature name="rightbracket" key="rightbracket"/>
+            <feature name="s" key="s"/>
+            <feature name="semicolon" key="semicolon"/>
+            <feature name="slash" key="slash"/>
+            <feature name="space" key="space"/>
+            <feature name="t" key="t"/>
+            <feature name="tab" key="tab"/>
+            <feature name="u" key="u"/>
+            <feature name="up" key="up"/>
+            <feature name="v" key="v"/>
+            <feature name="w" key="w"/>
+            <feature name="x" key="x"/>
+            <feature name="y" key="y"/>
+            <feature name="z" key="z"/>
         </controller>
         <controller id="game.controller.keyboard">
-            <feature name="0" key="0" />
-            <feature name="1" key="1" />
-            <feature name="2" key="2" />
-            <feature name="3" key="3" />
-            <feature name="4" key="4" />
-            <feature name="5" key="5" />
-            <feature name="6" key="6" />
-            <feature name="7" key="7" />
-            <feature name="8" key="8" />
-            <feature name="9" key="9" />
-            <feature name="a" key="a" />
-            <feature name="ampersand" key="ampersand" />
-            <feature name="asterisk" key="asterisk" />
-            <feature name="at" key="at" />
-            <feature name="b" key="b" />
-            <feature name="backslash" key="backslash" />
-            <feature name="backspace" key="backspace" />
-            <feature name="bar" key="bar" />
-            <feature name="break" key="break" />
-            <feature name="c" key="c" />
-            <feature name="capslock" key="capslock" />
-            <feature name="caret" key="caret" />
-            <feature name="clear" key="clear" />
-            <feature name="colon" key="colon" />
-            <feature name="comma" key="comma" />
-            <feature name="compose" key="compose" />
-            <feature name="d" key="d" />
-            <feature name="delete" key="delete" />
-            <feature name="dollar" key="dollar" />
-            <feature name="doublequote" key="doublequote" />
-            <feature name="down" key="down" />
-            <feature name="e" key="e" />
-            <feature name="end" key="end" />
-            <feature name="enter" key="enter" />
-            <feature name="equals" key="equals" />
-            <feature name="escape" key="escape" />
-            <feature name="euro" key="euro" />
-            <feature name="exclaim" key="exclaim" />
-            <feature name="f" key="f" />
-            <feature name="f1" key="f1" />
-            <feature name="f10" key="f10" />
-            <feature name="f11" key="f11" />
-            <feature name="f12" key="f12" />
-            <feature name="f13" key="f13" />
-            <feature name="f14" key="f14" />
-            <feature name="f15" key="f15" />
-            <feature name="f2" key="f2" />
-            <feature name="f3" key="f3" />
-            <feature name="f4" key="f4" />
-            <feature name="f5" key="f5" />
-            <feature name="f6" key="f6" />
-            <feature name="f7" key="f7" />
-            <feature name="f8" key="f8" />
-            <feature name="f9" key="f9" />
-            <feature name="g" key="g" />
-            <feature name="grave" key="grave" />
-            <feature name="greater" key="greater" />
-            <feature name="h" key="h" />
-            <feature name="hash" key="hash" />
-            <feature name="help" key="help" />
-            <feature name="home" key="home" />
-            <feature name="i" key="i" />
-            <feature name="insert" key="insert" />
-            <feature name="j" key="j" />
-            <feature name="k" key="k" />
-            <feature name="kp0" key="kp0" />
-            <feature name="kp1" key="kp1" />
-            <feature name="kp2" key="kp2" />
-            <feature name="kp3" key="kp3" />
-            <feature name="kp4" key="kp4" />
-            <feature name="kp5" key="kp5" />
-            <feature name="kp6" key="kp6" />
-            <feature name="kp7" key="kp7" />
-            <feature name="kp8" key="kp8" />
-            <feature name="kp9" key="kp9" />
-            <feature name="kpdivide" key="kpdivide" />
-            <feature name="kpenter" key="kpenter" />
-            <feature name="kpequals" key="kpequals" />
-            <feature name="kpminus" key="kpminus" />
-            <feature name="kpmultiply" key="kpmultiply" />
-            <feature name="kpperiod" key="kpperiod" />
-            <feature name="kpplus" key="kpplus" />
-            <feature name="l" key="l" />
-            <feature name="left" key="left" />
-            <feature name="leftalt" key="leftalt" />
-            <feature name="leftbrace" key="leftbrace" />
-            <feature name="leftbracket" key="leftbracket" />
-            <feature name="leftctrl" key="leftctrl" />
-            <feature name="leftmeta" key="leftmeta" />
-            <feature name="leftparen" key="leftparen" />
-            <feature name="leftshift" key="leftshift" />
-            <feature name="leftsuper" key="leftsuper" />
-            <feature name="less" key="less" />
-            <feature name="m" key="m" />
-            <feature name="menu" key="menu" />
-            <feature name="minus" key="minus" />
-            <feature name="mode" key="mode" />
-            <feature name="n" key="n" />
-            <feature name="numlock" key="numlock" />
-            <feature name="o" key="o" />
-            <feature name="p" key="p" />
-            <feature name="pagedown" key="pagedown" />
-            <feature name="pageup" key="pageup" />
-            <feature name="pause" key="pause" />
-            <feature name="period" key="period" />
-            <feature name="plus" key="plus" />
-            <feature name="power" key="power" />
-            <feature name="printscreen" key="printscreen" />
-            <feature name="q" key="q" />
-            <feature name="question" key="question" />
-            <feature name="quote" key="quote" />
-            <feature name="r" key="r" />
-            <feature name="right" key="right" />
-            <feature name="rightalt" key="rightalt" />
-            <feature name="rightbrace" key="rightbrace" />
-            <feature name="rightbracket" key="rightbracket" />
-            <feature name="rightctrl" key="rightctrl" />
-            <feature name="rightmeta" key="rightmeta" />
-            <feature name="rightparen" key="rightparen" />
-            <feature name="rightshift" key="rightshift" />
-            <feature name="rightsuper" key="rightsuper" />
-            <feature name="s" key="s" />
-            <feature name="scrolllock" key="scrolllock" />
-            <feature name="semicolon" key="semicolon" />
-            <feature name="slash" key="slash" />
-            <feature name="space" key="space" />
-            <feature name="sysreq" key="sysreq" />
-            <feature name="t" key="t" />
-            <feature name="tab" key="tab" />
-            <feature name="tilde" key="tilde" />
-            <feature name="u" key="u" />
-            <feature name="underscore" key="underscore" />
-            <feature name="undo" key="undo" />
-            <feature name="up" key="up" />
-            <feature name="v" key="v" />
-            <feature name="w" key="w" />
-            <feature name="x" key="x" />
-            <feature name="y" key="y" />
-            <feature name="z" key="z" />
+            <feature name="0" key="0"/>
+            <feature name="1" key="1"/>
+            <feature name="2" key="2"/>
+            <feature name="3" key="3"/>
+            <feature name="4" key="4"/>
+            <feature name="5" key="5"/>
+            <feature name="6" key="6"/>
+            <feature name="7" key="7"/>
+            <feature name="8" key="8"/>
+            <feature name="9" key="9"/>
+            <feature name="a" key="a"/>
+            <feature name="ampersand" key="ampersand"/>
+            <feature name="asterisk" key="asterisk"/>
+            <feature name="at" key="at"/>
+            <feature name="b" key="b"/>
+            <feature name="backslash" key="backslash"/>
+            <feature name="backspace" key="backspace"/>
+            <feature name="bar" key="bar"/>
+            <feature name="break" key="break"/>
+            <feature name="c" key="c"/>
+            <feature name="capslock" key="capslock"/>
+            <feature name="caret" key="caret"/>
+            <feature name="clear" key="clear"/>
+            <feature name="colon" key="colon"/>
+            <feature name="comma" key="comma"/>
+            <feature name="compose" key="compose"/>
+            <feature name="d" key="d"/>
+            <feature name="delete" key="delete"/>
+            <feature name="dollar" key="dollar"/>
+            <feature name="doublequote" key="doublequote"/>
+            <feature name="down" key="down"/>
+            <feature name="e" key="e"/>
+            <feature name="end" key="end"/>
+            <feature name="enter" key="enter"/>
+            <feature name="equals" key="equals"/>
+            <feature name="escape" key="escape"/>
+            <feature name="euro" key="euro"/>
+            <feature name="exclaim" key="exclaim"/>
+            <feature name="f" key="f"/>
+            <feature name="f1" key="f1"/>
+            <feature name="f10" key="f10"/>
+            <feature name="f11" key="f11"/>
+            <feature name="f12" key="f12"/>
+            <feature name="f13" key="f13"/>
+            <feature name="f14" key="f14"/>
+            <feature name="f15" key="f15"/>
+            <feature name="f2" key="f2"/>
+            <feature name="f3" key="f3"/>
+            <feature name="f4" key="f4"/>
+            <feature name="f5" key="f5"/>
+            <feature name="f6" key="f6"/>
+            <feature name="f7" key="f7"/>
+            <feature name="f8" key="f8"/>
+            <feature name="f9" key="f9"/>
+            <feature name="g" key="g"/>
+            <feature name="grave" key="grave"/>
+            <feature name="greater" key="greater"/>
+            <feature name="h" key="h"/>
+            <feature name="hash" key="hash"/>
+            <feature name="help" key="help"/>
+            <feature name="home" key="home"/>
+            <feature name="i" key="i"/>
+            <feature name="insert" key="insert"/>
+            <feature name="j" key="j"/>
+            <feature name="k" key="k"/>
+            <feature name="kp0" key="kp0"/>
+            <feature name="kp1" key="kp1"/>
+            <feature name="kp2" key="kp2"/>
+            <feature name="kp3" key="kp3"/>
+            <feature name="kp4" key="kp4"/>
+            <feature name="kp5" key="kp5"/>
+            <feature name="kp6" key="kp6"/>
+            <feature name="kp7" key="kp7"/>
+            <feature name="kp8" key="kp8"/>
+            <feature name="kp9" key="kp9"/>
+            <feature name="kpdivide" key="kpdivide"/>
+            <feature name="kpenter" key="kpenter"/>
+            <feature name="kpequals" key="kpequals"/>
+            <feature name="kpminus" key="kpminus"/>
+            <feature name="kpmultiply" key="kpmultiply"/>
+            <feature name="kpperiod" key="kpperiod"/>
+            <feature name="kpplus" key="kpplus"/>
+            <feature name="l" key="l"/>
+            <feature name="left" key="left"/>
+            <feature name="leftalt" key="leftalt"/>
+            <feature name="leftbrace" key="leftbrace"/>
+            <feature name="leftbracket" key="leftbracket"/>
+            <feature name="leftctrl" key="leftctrl"/>
+            <feature name="leftmeta" key="leftmeta"/>
+            <feature name="leftparen" key="leftparen"/>
+            <feature name="leftshift" key="leftshift"/>
+            <feature name="leftsuper" key="leftsuper"/>
+            <feature name="less" key="less"/>
+            <feature name="m" key="m"/>
+            <feature name="menu" key="menu"/>
+            <feature name="minus" key="minus"/>
+            <feature name="mode" key="mode"/>
+            <feature name="n" key="n"/>
+            <feature name="numlock" key="numlock"/>
+            <feature name="o" key="o"/>
+            <feature name="p" key="p"/>
+            <feature name="pagedown" key="pagedown"/>
+            <feature name="pageup" key="pageup"/>
+            <feature name="pause" key="pause"/>
+            <feature name="period" key="period"/>
+            <feature name="plus" key="plus"/>
+            <feature name="power" key="power"/>
+            <feature name="printscreen" key="printscreen"/>
+            <feature name="q" key="q"/>
+            <feature name="question" key="question"/>
+            <feature name="quote" key="quote"/>
+            <feature name="r" key="r"/>
+            <feature name="right" key="right"/>
+            <feature name="rightalt" key="rightalt"/>
+            <feature name="rightbrace" key="rightbrace"/>
+            <feature name="rightbracket" key="rightbracket"/>
+            <feature name="rightctrl" key="rightctrl"/>
+            <feature name="rightmeta" key="rightmeta"/>
+            <feature name="rightparen" key="rightparen"/>
+            <feature name="rightshift" key="rightshift"/>
+            <feature name="rightsuper" key="rightsuper"/>
+            <feature name="s" key="s"/>
+            <feature name="scrolllock" key="scrolllock"/>
+            <feature name="semicolon" key="semicolon"/>
+            <feature name="slash" key="slash"/>
+            <feature name="space" key="space"/>
+            <feature name="sysreq" key="sysreq"/>
+            <feature name="t" key="t"/>
+            <feature name="tab" key="tab"/>
+            <feature name="tilde" key="tilde"/>
+            <feature name="u" key="u"/>
+            <feature name="underscore" key="underscore"/>
+            <feature name="undo" key="undo"/>
+            <feature name="up" key="up"/>
+            <feature name="v" key="v"/>
+            <feature name="w" key="w"/>
+            <feature name="x" key="x"/>
+            <feature name="y" key="y"/>
+            <feature name="z" key="z"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/application/Mouse.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/application/Mouse.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Mouse" provider="application">
         <controller id="game.controller.mouse">
-            <feature name="button4" mouse="button4" />
-            <feature name="button5" mouse="button5" />
-            <feature name="horizwheelleft" mouse="horizwheelleft" />
-            <feature name="horizwheelright" mouse="horizwheelright" />
-            <feature name="left" mouse="left" />
-            <feature name="middle" mouse="middle" />
+            <feature name="button4" mouse="button4"/>
+            <feature name="button5" mouse="button5"/>
+            <feature name="horizwheelleft" mouse="horizwheelleft"/>
+            <feature name="horizwheelright" mouse="horizwheelright"/>
+            <feature name="left" mouse="left"/>
+            <feature name="middle" mouse="middle"/>
             <feature name="pointer">
-                <up axis="-y" />
-                <down axis="+y" />
-                <right axis="+x" />
-                <left axis="-x" />
+                <up axis="-y"/>
+                <down axis="+y"/>
+                <right axis="+x"/>
+                <left axis="-x"/>
             </feature>
-            <feature name="right" mouse="right" />
-            <feature name="wheeldown" mouse="wheeldown" />
-            <feature name="wheelup" mouse="wheelup" />
+            <feature name="right" mouse="right"/>
+            <feature name="wheeldown" mouse="wheeldown"/>
+            <feature name="wheelup" mouse="wheelup"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/8Bitdo_Zero_GamePad_v05A0_p3232_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/8Bitdo_Zero_GamePad_v05A0_p3232_16b_4a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="8Bitdo Zero GamePad" provider="cocoa" vid="05A0" pid="3232" buttoncount="16" axiscount="4">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="10" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="10"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/DUALSHOCK_4_Wireless_Controller_v054C_p09CC_14b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/DUALSHOCK_4_Wireless_Controller_v054C_p09CC_14b_6a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="DUALSHOCK 4 Wireless Controller" provider="cocoa" vid="054C" pid="09CC" buttoncount="14" axiscount="6">
         <configuration>
-            <appearance id="game.controller.ps.dualshock" />
-            <axis index="4" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualshock"/>
+            <axis index="4" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="guide" button="13" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="guide" button="13"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="9" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="9"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/GamePad_Pro_USB_v0428_p4001_10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/GamePad_Pro_USB_v0428_p4001_10b_2a.xml
@@ -1,21 +1,21 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="GamePad Pro USB" provider="cocoa" vid="0428" pid="4001" buttoncount="10" axiscount="2">
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="5" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/Gamepad_F310_v046D_pC21D_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/Gamepad_F310_v046D_pC21D_15b_6a.xml
@@ -1,40 +1,40 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Gamepad F310" provider="cocoa" vid="046D" pid="C21D" buttoncount="15" axiscount="6">
         <configuration>
-            <axis index="4" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <axis index="4" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="9" />
-            <feature name="down" button="12" />
-            <feature name="guide" button="10" />
-            <feature name="left" button="13" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="9"/>
+            <feature name="down" button="12"/>
+            <feature name="guide" button="10"/>
+            <feature name="left" button="13"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="6" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="right" button="14" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="6"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="right" button="14"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="7" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="8" />
-            <feature name="up" button="11" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="7"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="11"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/Generic_USB_Joystick_v0079_p0006_12b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/Generic_USB_Joystick_v0079_p0006_12b_6a.xml
@@ -1,26 +1,26 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Generic   USB  Joystick" provider="cocoa" vid="0079" pid="0006" buttoncount="12" axiscount="6">
         <configuration>
-            <appearance id="game.controller.n64" />
+            <appearance id="game.controller.n64"/>
         </configuration>
         <controller id="game.controller.n64">
-            <feature name="a" button="6" />
+            <feature name="a" button="6"/>
             <feature name="analogstick">
-                <up axis="-2" />
-                <down axis="+2" />
-                <right axis="+1" />
-                <left axis="-1" />
+                <up axis="-2"/>
+                <down axis="+2"/>
+                <right axis="+1"/>
+                <left axis="-1"/>
             </feature>
-            <feature name="b" button="8" />
-            <feature name="cdown" button="2" />
-            <feature name="cleft" button="3" />
-            <feature name="cright" button="1" />
-            <feature name="cup" button="0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="rightbumper" button="5" />
-            <feature name="start" button="9" />
-            <feature name="z" button="7" />
+            <feature name="b" button="8"/>
+            <feature name="cdown" button="2"/>
+            <feature name="cleft" button="3"/>
+            <feature name="cright" button="1"/>
+            <feature name="cup" button="0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="start" button="9"/>
+            <feature name="z" button="7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/Logitech_Dual_Action_v046D_pC216_12b_5a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/Logitech_Dual_Action_v046D_pC216_12b_5a.xml
@@ -1,31 +1,31 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Logitech Dual Action" provider="cocoa" vid="046D" pid="C216" buttoncount="12" axiscount="5">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-2" />
-                <down axis="+2" />
-                <right axis="+1" />
-                <left axis="-1" />
+                <up axis="-2"/>
+                <down axis="+2"/>
+                <right axis="+1"/>
+                <left axis="-1"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/PC_USB_Wired_Stick_8838_v0738_p8838_13b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/PC_USB_Wired_Stick_8838_v0738_p8838_13b_4a.xml
@@ -1,28 +1,28 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="PC USB Wired Stick 8838" provider="cocoa" vid="0738" pid="8838" buttoncount="13" axiscount="4">
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+1" />
-            <feature name="guide" button="12" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+1"/>
+            <feature name="guide" button="12"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="leftthumb" button="7" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightthumb" button="5" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="leftthumb" button="7"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightthumb" button="5"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/PLAYSTATION_R_3_Controller_v054C_p0268_19b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/PLAYSTATION_R_3_Controller_v054C_p0268_19b_4a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="PLAYSTATION(R)3 Controller" provider="cocoa" vid="054C" pid="0268" buttoncount="19" axiscount="4">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="14" />
-            <feature name="b" button="13" />
-            <feature name="back" button="0" />
-            <feature name="down" button="6" />
-            <feature name="guide" button="16" />
-            <feature name="left" button="7" />
-            <feature name="leftbumper" button="10" />
+            <feature name="a" button="14"/>
+            <feature name="b" button="13"/>
+            <feature name="back" button="0"/>
+            <feature name="down" button="6"/>
+            <feature name="guide" button="16"/>
+            <feature name="left" button="7"/>
+            <feature name="leftbumper" button="10"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="1" />
-            <feature name="lefttrigger" button="8" />
-            <feature name="right" button="5" />
-            <feature name="rightbumper" button="11" />
+            <feature name="leftthumb" button="1"/>
+            <feature name="lefttrigger" button="8"/>
+            <feature name="right" button="5"/>
+            <feature name="rightbumper" button="11"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="2" />
-            <feature name="righttrigger" button="9" />
-            <feature name="start" button="3" />
-            <feature name="up" button="4" />
-            <feature name="x" button="15" />
-            <feature name="y" button="12" />
+            <feature name="rightthumb" button="2"/>
+            <feature name="righttrigger" button="9"/>
+            <feature name="start" button="3"/>
+            <feature name="up" button="4"/>
+            <feature name="x" button="15"/>
+            <feature name="y" button="12"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/PS_R__Ga_epad_v054C_p0268_19b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/PS_R__Ga_epad_v054C_p0268_19b_4a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="PS(R) Ga`epad" provider="cocoa" vid="054C" pid="0268" buttoncount="19" axiscount="4">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="14" />
-            <feature name="b" button="13" />
-            <feature name="back" button="0" />
-            <feature name="down" button="6" />
-            <feature name="guide" button="16" />
-            <feature name="left" button="17" />
-            <feature name="leftbumper" button="10" />
+            <feature name="a" button="14"/>
+            <feature name="b" button="13"/>
+            <feature name="back" button="0"/>
+            <feature name="down" button="6"/>
+            <feature name="guide" button="16"/>
+            <feature name="left" button="17"/>
+            <feature name="leftbumper" button="10"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="1" />
-            <feature name="lefttrigger" button="8" />
-            <feature name="right" button="5" />
-            <feature name="rightbumper" button="11" />
+            <feature name="leftthumb" button="1"/>
+            <feature name="lefttrigger" button="8"/>
+            <feature name="right" button="5"/>
+            <feature name="rightbumper" button="11"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="2" />
-            <feature name="righttrigger" button="9" />
-            <feature name="start" button="3" />
-            <feature name="up" button="4" />
-            <feature name="x" button="15" />
-            <feature name="y" button="12" />
+            <feature name="rightthumb" button="2"/>
+            <feature name="righttrigger" button="9"/>
+            <feature name="start" button="3"/>
+            <feature name="up" button="4"/>
+            <feature name="x" button="15"/>
+            <feature name="y" button="12"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/USB_GamePad_v0E8F_p3013_16b_10a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/USB_GamePad_v0E8F_p3013_16b_10a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="USB GamePad" provider="cocoa" vid="0E8F" pid="3013" buttoncount="16" axiscount="10">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+9" />
-            <feature name="left" axis="-8" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+8" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-9" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+9"/>
+            <feature name="left" axis="-8"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+8"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-9"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/USB_Gamepad_v0079_p0011_10b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/USB_Gamepad_v0079_p0011_10b_6a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="USB Gamepad" provider="cocoa" vid="0079" pid="0011" buttoncount="10" axiscount="6">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+5" />
-            <feature name="left" axis="-4" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+4" />
-            <feature name="rightbumper" button="5" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-5" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+5"/>
+            <feature name="left" axis="-4"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+4"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-5"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/USB_Joystick_v0E8F_p0003_12b_5a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/USB_Joystick_v0E8F_p0003_12b_5a.xml
@@ -1,31 +1,31 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="USB Joystick" provider="cocoa" vid="0E8F" pid="0003" buttoncount="12" axiscount="5">
         <controller id="game.controller.default">
-            <feature name="a" button="2" />
-            <feature name="b" button="3" />
-            <feature name="back" button="8" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="3"/>
+            <feature name="back" button="8"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="x" button="0" />
-            <feature name="y" button="1" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="1"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/Wireless_360_Controller_v045E_p028E_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/Wireless_360_Controller_v045E_p028E_15b_6a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Wireless 360 Controller" provider="cocoa" vid="045E" pid="028E" buttoncount="15" axiscount="6">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="4" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="4" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="9" />
-            <feature name="down" button="12" />
-            <feature name="guide" button="10" />
-            <feature name="left" button="13" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="9"/>
+            <feature name="down" button="12"/>
+            <feature name="guide" button="10"/>
+            <feature name="left" button="13"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="6" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="right" button="14" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="6"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="right" button="14"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="7" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="8" />
-            <feature name="up" button="11" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="7"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="11"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/Wireless_Controller_v054C_p09CC_14b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/Wireless_Controller_v054C_p09CC_14b_6a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Wireless Controller" provider="cocoa" vid="054C" pid="09CC" buttoncount="14" axiscount="6">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="4" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="4" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="guide" button="13" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="guide" button="13"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="9" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="9"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/Xbox_360_Wired_Controller_v045E_p028E_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/Xbox_360_Wired_Controller_v045E_p028E_15b_6a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wired Controller" provider="cocoa" vid="045E" pid="028E" buttoncount="15" axiscount="6">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="4" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="4" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="9" />
-            <feature name="down" button="12" />
-            <feature name="guide" button="10" />
-            <feature name="left" button="13" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="9"/>
+            <feature name="down" button="12"/>
+            <feature name="guide" button="10"/>
+            <feature name="left" button="13"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="6" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="right" button="14" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="6"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="right" button="14"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="7" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="8" />
-            <feature name="up" button="11" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="7"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="11"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/Xbox_360_Wired_Controller_v046D_pC21D_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/Xbox_360_Wired_Controller_v046D_pC21D_15b_6a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wired Controller" provider="cocoa" vid="046D" pid="C21D" buttoncount="15" axiscount="6">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="4" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="4" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="9" />
-            <feature name="down" button="12" />
-            <feature name="guide" button="10" />
-            <feature name="left" button="13" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="9"/>
+            <feature name="down" button="12"/>
+            <feature name="guide" button="10"/>
+            <feature name="left" button="13"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="6" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="right" button="14" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="6"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="right" button="14"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="7" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="8" />
-            <feature name="up" button="11" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="7"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="11"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/Xbox_One_Wired_Controller_v045E_p02DD_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/Xbox_One_Wired_Controller_v045E_p02DD_15b_6a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox One Wired Controller" provider="cocoa" vid="045E" pid="02DD" buttoncount="15" axiscount="6">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="4" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="4" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="9" />
-            <feature name="down" button="12" />
-            <feature name="guide" button="10" />
-            <feature name="left" button="13" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="9"/>
+            <feature name="down" button="12"/>
+            <feature name="guide" button="10"/>
+            <feature name="left" button="13"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="6" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="right" button="14" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="6"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="right" button="14"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="7" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="8" />
-            <feature name="up" button="11" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="7"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="11"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/usb_gamepad____________v0810_pE501_10b_3a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/usb_gamepad____________v0810_pE501_10b_3a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="usb gamepad           " provider="cocoa" vid="0810" pid="E501" buttoncount="10" axiscount="3">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+2" />
-            <feature name="left" axis="-1" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+1" />
-            <feature name="rightbumper" button="6" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-2" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+2"/>
+            <feature name="left" axis="-1"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+1"/>
+            <feature name="rightbumper" button="6"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-2"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/cocoa/usb_gamepad_v0810_pE501_10b_3a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/cocoa/usb_gamepad_v0810_pE501_10b_3a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="usb gamepad" provider="cocoa" vid="0810" pid="E501" buttoncount="10" axiscount="3">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+2" />
-            <feature name="left" axis="-1" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+1" />
-            <feature name="rightbumper" button="6" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-2" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+2"/>
+            <feature name="left" axis="-1"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+1"/>
+            <feature name="rightbumper" button="6"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-2"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_13b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_13b_4a.xml
@@ -1,31 +1,31 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Extended Gamepad" provider="darwinembedded" buttoncount="13" axiscount="4">
         <controller id="game.controller.default">
-            <feature name="up" button="0" />
-            <feature name="down" button="1" />
-            <feature name="left" button="2" />
-            <feature name="right" button="3" />
-            <feature name="a" button="4" />
-            <feature name="b" button="5" />
-            <feature name="x" button="6" />
-            <feature name="y" button="7" />
-            <feature name="leftbumper" button="8" />
-            <feature name="lefttrigger" button="9" />
-            <feature name="rightbumper" button="10" />
-            <feature name="righttrigger" button="11" />
-            <feature name="start" button="12" />
+            <feature name="up" button="0"/>
+            <feature name="down" button="1"/>
+            <feature name="left" button="2"/>
+            <feature name="right" button="3"/>
+            <feature name="a" button="4"/>
+            <feature name="b" button="5"/>
+            <feature name="x" button="6"/>
+            <feature name="y" button="7"/>
+            <feature name="leftbumper" button="8"/>
+            <feature name="lefttrigger" button="9"/>
+            <feature name="rightbumper" button="10"/>
+            <feature name="righttrigger" button="11"/>
+            <feature name="start" button="12"/>
             <feature name="leftstick">
-                <up axis="+1" />
-                <down axis="-1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="+1"/>
+                <down axis="-1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="rightstick">
-                <up axis="+3" />
-                <down axis="-3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="+3"/>
+                <down axis="-3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
         </controller>
     </device>

--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_15b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_15b_4a.xml
@@ -1,33 +1,33 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Extended Gamepad" provider="darwinembedded" buttoncount="15" axiscount="4">
         <controller id="game.controller.default">
-            <feature name="up" button="0" />
-            <feature name="down" button="1" />
-            <feature name="left" button="2" />
-            <feature name="right" button="3" />
-            <feature name="a" button="4" />
-            <feature name="b" button="5" />
-            <feature name="x" button="6" />
-            <feature name="y" button="7" />
-            <feature name="leftbumper" button="8" />
-            <feature name="lefttrigger" button="9" />
-            <feature name="rightbumper" button="10" />
-            <feature name="righttrigger" button="11" />
-            <feature name="start" button="12" />
-            <feature name="leftthumb" button="14" />
-            <feature name="rightthumb" button="15" />
+            <feature name="up" button="0"/>
+            <feature name="down" button="1"/>
+            <feature name="left" button="2"/>
+            <feature name="right" button="3"/>
+            <feature name="a" button="4"/>
+            <feature name="b" button="5"/>
+            <feature name="x" button="6"/>
+            <feature name="y" button="7"/>
+            <feature name="leftbumper" button="8"/>
+            <feature name="lefttrigger" button="9"/>
+            <feature name="rightbumper" button="10"/>
+            <feature name="righttrigger" button="11"/>
+            <feature name="start" button="12"/>
+            <feature name="leftthumb" button="14"/>
+            <feature name="rightthumb" button="15"/>
             <feature name="leftstick">
-                <up axis="+1" />
-                <down axis="-1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="+1"/>
+                <down axis="-1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="rightstick">
-                <up axis="+3" />
-                <down axis="-3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="+3"/>
+                <down axis="-3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
         </controller>
     </device>

--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Extended_Gamepad_16b_4a.xml
@@ -1,34 +1,34 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Extended Gamepad" provider="darwinembedded" buttoncount="16" axiscount="4">
         <controller id="game.controller.default">
-            <feature name="up" button="0" />
-            <feature name="down" button="1" />
-            <feature name="left" button="2" />
-            <feature name="right" button="3" />
-            <feature name="a" button="4" />
-            <feature name="b" button="5" />
-            <feature name="x" button="6" />
-            <feature name="y" button="7" />
-            <feature name="leftbumper" button="8" />
-            <feature name="lefttrigger" button="9" />
-            <feature name="rightbumper" button="10" />
-            <feature name="righttrigger" button="11" />
-            <feature name="start" button="12" />
-            <feature name="back" button="13" />
-            <feature name="leftthumb" button="14" />
-            <feature name="rightthumb" button="15" />
+            <feature name="up" button="0"/>
+            <feature name="down" button="1"/>
+            <feature name="left" button="2"/>
+            <feature name="right" button="3"/>
+            <feature name="a" button="4"/>
+            <feature name="b" button="5"/>
+            <feature name="x" button="6"/>
+            <feature name="y" button="7"/>
+            <feature name="leftbumper" button="8"/>
+            <feature name="lefttrigger" button="9"/>
+            <feature name="rightbumper" button="10"/>
+            <feature name="righttrigger" button="11"/>
+            <feature name="start" button="12"/>
+            <feature name="back" button="13"/>
+            <feature name="leftthumb" button="14"/>
+            <feature name="rightthumb" button="15"/>
             <feature name="leftstick">
-                <up axis="+1" />
-                <down axis="-1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="+1"/>
+                <down axis="-1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="rightstick">
-                <up axis="+3" />
-                <down axis="-3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="+3"/>
+                <down axis="-3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
         </controller>
     </device>

--- a/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Micro_Gamepad_6b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/darwinembedded/Micro_Gamepad_6b.xml
@@ -1,14 +1,14 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Micro Gamepad" provider="darwinembedded" buttoncount="6">
         <controller id="game.controller.default">
-            <feature name="up" button="0" />
-            <feature name="down" button="1" />
-            <feature name="left" button="2" />
-            <feature name="right" button="3" />
-            <feature name="start" button="4" />
-            <feature name="a" button="5" />
-            <feature name="x" button="6" />
+            <feature name="up" button="0"/>
+            <feature name="down" button="1"/>
+            <feature name="left" button="2"/>
+            <feature name="right" button="3"/>
+            <feature name="start" button="4"/>
+            <feature name="a" button="5"/>
+            <feature name="x" button="6"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/4-PLAY_PORT.1_v16D0_p0D04_24b_1h_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/4-PLAY_PORT.1_v16D0_p0D04_24b_1h_8a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="4-PLAY PORT.1" provider="directinput" vid="16D0" pid="0D04" buttoncount="24" hatcount="1" axiscount="8">
         <configuration>
-            <appearance id="game.controller.genesis.6button" />
+            <appearance id="game.controller.genesis.6button"/>
         </configuration>
         <controller id="game.controller.genesis.6button">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="c" button="9" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="mode" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="start" button="5" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
-            <feature name="z" button="8" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="c" button="9"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="mode" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="start" button="5"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="8"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/4_axis_16_button_joystick_v6666_p0667_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/4_axis_16_button_joystick_v6666_p0667_16b_4a.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="4 axis 16 button joystick" provider="directinput" vid="6666" pid="0667" buttoncount="16" axiscount="4">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/Adaptoid_v06F7_p1_14b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/Adaptoid_v06F7_p1_14b_2a.xml
@@ -1,27 +1,27 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Adaptoid" provider="directinput" vid="06F7" pid="0001" buttoncount="14" axiscount="2">
         <controller id="game.controller.n64">
-            <feature name="a" button="0" />
+            <feature name="a" button="0"/>
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="3" />
-            <feature name="cdown" button="1" />
-            <feature name="cleft" button="4" />
-            <feature name="cright" button="2" />
-            <feature name="cup" button="5" />
-            <feature name="down" button="11" />
-            <feature name="left" button="12" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" button="13" />
-            <feature name="rightbumper" button="7" />
-            <feature name="start" button="8" />
-            <feature name="up" button="10" />
-            <feature name="z" button="9" />
+            <feature name="b" button="3"/>
+            <feature name="cdown" button="1"/>
+            <feature name="cleft" button="4"/>
+            <feature name="cright" button="2"/>
+            <feature name="cup" button="5"/>
+            <feature name="down" button="11"/>
+            <feature name="left" button="12"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" button="13"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="10"/>
+            <feature name="z" button="9"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/Bluetooth_HID_Port_v05A0_p3232_16b_1h_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/Bluetooth_HID_Port_v05A0_p3232_16b_1h_6a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Bluetooth HID Port" provider="directinput" vid="05A0" pid="3232" buttoncount="16" hatcount="1" axiscount="6">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="10" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="10"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/GamePad_Pro_USB_v0428_p4001_10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/GamePad_Pro_USB_v0428_p4001_10b_2a.xml
@@ -1,21 +1,21 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="GamePad Pro USB" provider="directinput" vid="0428" pid="4001" buttoncount="10" axiscount="2">
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="5" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/Generic_USB_Joystick_v0079_p0006_12b_1h_5a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/Generic_USB_Joystick_v0079_p0006_12b_1h_5a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Generic   USB  Joystick" provider="directinput" vid="0079" pid="0006" buttoncount="12" hatcount="1" axiscount="5">
         <controller id="game.controller.default">
-            <feature name="a" button="2" />
-            <feature name="b" button="1" />
-            <feature name="back" button="8" />
-            <feature name="down" hat="h0down" />
-            <feature name="left" hat="h0left" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="8"/>
+            <feature name="down" hat="h0down"/>
+            <feature name="left" hat="h0left"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" hat="h0right" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" hat="h0right"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" hat="h0up" />
-            <feature name="x" button="3" />
-            <feature name="y" button="0" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" hat="h0up"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="0"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/Generic___USB__Joystick___v0079_p0006_12b_1h_5a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/Generic___USB__Joystick___v0079_p0006_12b_1h_5a.xml
@@ -1,30 +1,30 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Generic   USB  Joystick  " provider="directinput" vid="0079" pid="0006" buttoncount="12" hatcount="1" axiscount="5">
         <configuration>
-            <appearance id="game.controller.n64" />
+            <appearance id="game.controller.n64"/>
         </configuration>
         <controller id="game.controller.n64">
-            <feature name="a" button="6" />
+            <feature name="a" button="6"/>
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="8" />
-            <feature name="cdown" button="2" />
-            <feature name="cleft" button="3" />
-            <feature name="cright" button="1" />
-            <feature name="cup" button="0" />
-            <feature name="down" hat="h0down" />
-            <feature name="left" hat="h0left" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" hat="h0right" />
-            <feature name="rightbumper" button="5" />
-            <feature name="start" button="9" />
-            <feature name="up" hat="h0up" />
-            <feature name="z" button="7" />
+            <feature name="b" button="8"/>
+            <feature name="cdown" button="2"/>
+            <feature name="cleft" button="3"/>
+            <feature name="cright" button="1"/>
+            <feature name="cup" button="0"/>
+            <feature name="down" hat="h0down"/>
+            <feature name="left" hat="h0left"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" hat="h0right"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="start" button="9"/>
+            <feature name="up" hat="h0up"/>
+            <feature name="z" button="7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/Logitech_Dual_Action_v046D_pC216_12b_1h_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/Logitech_Dual_Action_v046D_pC216_12b_1h_4a.xml
@@ -1,34 +1,34 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Logitech Dual Action" provider="directinput" vid="046D" pid="C216" buttoncount="12" hatcount="1" axiscount="4">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" hat="h0down" />
-            <feature name="left" hat="h0left" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" hat="h0down"/>
+            <feature name="left" hat="h0left"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" hat="h0right" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" hat="h0right"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <right axis="+2" />
-                <left axis="-2" />
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" hat="h0up" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" hat="h0up"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/Logitech_RumblePad_2_USB_v046D_pC218_12b_1h_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/Logitech_RumblePad_2_USB_v046D_pC218_12b_1h_4a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Logitech RumblePad 2 USB" provider="directinput" vid="046D" pid="C218" buttoncount="12" hatcount="1" axiscount="4">
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" hat="h0down" />
-            <feature name="left" hat="h0left" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" hat="h0down"/>
+            <feature name="left" hat="h0left"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" hat="h0right" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" hat="h0right"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" hat="h0up" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" hat="h0up"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/MAYFLASH_GameCube_Controller_Adapter_v0079_p1844_16b_1h_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/MAYFLASH_GameCube_Controller_Adapter_v0079_p1844_16b_1h_6a.xml
@@ -1,37 +1,37 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="MAYFLASH GameCube Controller Adapter" provider="directinput" vid="0079" pid="1844" buttoncount="16" hatcount="1" axiscount="6">
         <configuration>
-            <appearance id="game.controller.gamecube" />
-            <axis index="3" center="-1" range="1" />
-            <axis index="4" center="-1" range="2" />
-            <button index="4" ignore="true" />
-            <button index="5" ignore="true" />
+            <appearance id="game.controller.gamecube"/>
+            <axis index="3" center="-1" range="1"/>
+            <axis index="4" center="-1" range="2"/>
+            <button index="4" ignore="true"/>
+            <button index="5" ignore="true"/>
         </configuration>
         <controller id="game.controller.gamecube">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
             <feature name="controlstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="cstick">
-                <up axis="-2" />
-                <down axis="+2" />
-                <right axis="+5" />
-                <left axis="-5" />
+                <up axis="-2"/>
+                <down axis="+2"/>
+                <right axis="+5"/>
+                <left axis="-5"/>
             </feature>
-            <feature name="down" button="14" />
-            <feature name="l" axis="+3" />
-            <feature name="left" button="15" />
-            <feature name="right" button="13" />
-            <feature name="start" button="9" />
-            <feature name="up" button="12" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
-            <feature name="z" button="7" />
+            <feature name="down" button="14"/>
+            <feature name="l" axis="+3"/>
+            <feature name="left" button="15"/>
+            <feature name="right" button="13"/>
+            <feature name="start" button="9"/>
+            <feature name="up" button="12"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/PS_R__Ga_epad_v054C_p0268_19b_5a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/PS_R__Ga_epad_v054C_p0268_19b_5a.xml
@@ -1,37 +1,37 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="PS(R) Ga`epad" provider="directinput" vid="054C" pid="0268" buttoncount="19" axiscount="5">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="16" />
-            <feature name="circle" button="13" />
-            <feature name="cross" button="14" />
-            <feature name="down" button="6" />
-            <feature name="l3" button="1" />
-            <feature name="left" button="7" />
-            <feature name="leftbumper" button="10" />
+            <feature name="analog" button="16"/>
+            <feature name="circle" button="13"/>
+            <feature name="cross" button="14"/>
+            <feature name="down" button="6"/>
+            <feature name="l3" button="1"/>
+            <feature name="left" button="7"/>
+            <feature name="leftbumper" button="10"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" button="8" />
-            <feature name="r3" button="2" />
-            <feature name="right" button="5" />
-            <feature name="rightbumper" button="11" />
+            <feature name="lefttrigger" button="8"/>
+            <feature name="r3" button="2"/>
+            <feature name="right" button="5"/>
+            <feature name="rightbumper" button="11"/>
             <feature name="rightstick">
-                <right axis="+2" />
-                <left axis="-2" />
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="righttrigger" button="9" />
-            <feature name="select" button="0" />
-            <feature name="square" button="15" />
-            <feature name="start" button="3" />
-            <feature name="triangle" button="12" />
-            <feature name="up" button="4" />
+            <feature name="righttrigger" button="9"/>
+            <feature name="select" button="0"/>
+            <feature name="square" button="15"/>
+            <feature name="start" button="3"/>
+            <feature name="triangle" button="12"/>
+            <feature name="up" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/Twin_USB_Joystick_v0810_p0001_12b_1h_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/Twin_USB_Joystick_v0810_p0001_12b_1h_4a.xml
@@ -1,33 +1,33 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Twin USB Joystick" provider="directinput" vid="0810" pid="0001" buttoncount="12" hatcount="1" axiscount="4">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.default">
-            <feature name="a" button="2" />
-            <feature name="b" button="1" />
-            <feature name="back" button="8" />
-            <feature name="down" hat="h0down" />
-            <feature name="left" hat="h0left" />
-            <feature name="leftbumper" button="6" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="8"/>
+            <feature name="down" hat="h0down"/>
+            <feature name="left" hat="h0left"/>
+            <feature name="leftbumper" button="6"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="4" />
-            <feature name="right" hat="h0right" />
-            <feature name="rightbumper" button="7" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="4"/>
+            <feature name="right" hat="h0right"/>
+            <feature name="rightbumper" button="7"/>
             <feature name="rightstick">
-                <up axis="-2" />
+                <up axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="5" />
-            <feature name="start" button="9" />
-            <feature name="up" hat="h0up" />
-            <feature name="x" button="3" />
-            <feature name="y" button="0" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="5"/>
+            <feature name="start" button="9"/>
+            <feature name="up" hat="h0up"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="0"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/USB_GamePad_v0E8F_p3013_16b_1h_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/USB_GamePad_v0E8F_p3013_16b_1h_4a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="USB GamePad" provider="directinput" vid="0E8F" pid="3013" buttoncount="16" hatcount="1" axiscount="4">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/USB_Gamepad_v0079_p0011_10b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/USB_Gamepad_v0079_p0011_10b_6a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="USB Gamepad" provider="directinput" vid="0079" pid="0011" buttoncount="10" axiscount="6">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="5" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/USB_Joystick_v0E8F_p3_12b_1h_5a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/USB_Joystick_v0E8F_p3_12b_1h_5a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="USB Joystick" provider="directinput" vid="0E8F" pid="0003" buttoncount="12" hatcount="1" axiscount="5">
         <controller id="game.controller.default">
-            <feature name="a" button="2" />
-            <feature name="b" button="3" />
-            <feature name="back" button="8" />
-            <feature name="down" hat="h0down" />
-            <feature name="left" hat="h0left" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="3"/>
+            <feature name="back" button="8"/>
+            <feature name="down" hat="h0down"/>
+            <feature name="left" hat="h0left"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="5" />
-            <feature name="right" hat="h0right" />
-            <feature name="rightbumper" button="6" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="5"/>
+            <feature name="right" hat="h0right"/>
+            <feature name="rightbumper" button="6"/>
             <feature name="rightstick">
-                <up axis="-2" />
-                <down axis="+2" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-2"/>
+                <down axis="+2"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" hat="h0up" />
-            <feature name="x" button="0" />
-            <feature name="y" button="1" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" hat="h0up"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="1"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/Wireless_Controller_v054C_p09CC_14b_1h_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/Wireless_Controller_v054C_p09CC_14b_1h_6a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Wireless Controller" provider="directinput" vid="054C" pid="09CC" buttoncount="14" hatcount="1" axiscount="6">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="3" center="-1" range="2" />
-            <axis index="4" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="3" center="-1" range="2"/>
+            <axis index="4" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="12" />
-            <feature name="circle" button="2" />
-            <feature name="cross" button="1" />
-            <feature name="down" hat="h0down" />
-            <feature name="l3" button="10" />
-            <feature name="left" hat="h0left" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="12"/>
+            <feature name="circle" button="2"/>
+            <feature name="cross" button="1"/>
+            <feature name="down" hat="h0down"/>
+            <feature name="l3" button="10"/>
+            <feature name="left" hat="h0left"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+3" />
-            <feature name="r3" button="11" />
-            <feature name="right" hat="h0right" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+3"/>
+            <feature name="r3" button="11"/>
+            <feature name="right" hat="h0right"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-5" />
-                <down axis="+5" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-5"/>
+                <down axis="+5"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="righttrigger" axis="+4" />
-            <feature name="select" button="8" />
-            <feature name="square" button="0" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="3" />
-            <feature name="up" hat="h0up" />
+            <feature name="righttrigger" axis="+4"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="0"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="3"/>
+            <feature name="up" hat="h0up"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/usb_gamepad____________v0810_pE501_10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/usb_gamepad____________v0810_pE501_10b_2a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="usb gamepad           " provider="directinput" vid="0810" pid="E501" buttoncount="10" axiscount="2">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="6" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="6"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/directinput/usb_gamepad_v0810_pE501_10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/directinput/usb_gamepad_v0810_pE501_10b_2a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="usb gamepad" provider="directinput" vid="0810" pid="E501" buttoncount="10" axiscount="2">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="6" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="6"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/8BitDo_M30_gamepad_16b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/8BitDo_M30_gamepad_16b_8a.xml
@@ -1,25 +1,25 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="8BitDo M30 gamepad" provider="linux" buttoncount="16" axiscount="8">
         <configuration>
-            <appearance id="game.controller.saturn" />
-            <axis index="4" center="-1" range="2" ignore="true" />
-            <axis index="5" center="-1" range="2" ignore="true" />
+            <appearance id="game.controller.saturn"/>
+            <axis index="4" center="-1" range="2" ignore="true"/>
+            <axis index="5" center="-1" range="2" ignore="true"/>
         </configuration>
         <controller id="game.controller.saturn">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="c" button="7" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="8" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="9" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
-            <feature name="z" button="6" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="c" button="7"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="8"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="9"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
+            <feature name="z" button="6"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_Arcade_x__10b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_Arcade_x__10b_8a.xml
@@ -1,25 +1,25 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="8Bitdo NES30 Arcade(x)" provider="linux" buttoncount="10" axiscount="8">
         <configuration>
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="4" />
-            <feature name="down" axis="+1" />
-            <feature name="guide" button="7" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" axis="+5" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" axis="+2" />
-            <feature name="select" button="6" />
-            <feature name="start" button="5" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="4"/>
+            <feature name="down" axis="+1"/>
+            <feature name="guide" button="7"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" axis="+5"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" axis="+2"/>
+            <feature name="select" button="6"/>
+            <feature name="start" button="5"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_GamePad_16b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_GamePad_16b_8a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="8Bitdo NES30 GamePad" provider="linux" buttoncount="16" axiscount="8">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="10" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="10"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_GamePad_Joystick_22b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_NES30_GamePad_Joystick_22b_8a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="8Bitdo NES30 GamePad Joystick" provider="linux" buttoncount="22" axiscount="8">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="10" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="10"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_SFC30_GamePad_Joystick_22b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_SFC30_GamePad_Joystick_22b_8a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="8Bitdo SFC30 GamePad Joystick" provider="linux" buttoncount="22" axiscount="8">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="10" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="10"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_Zero_GamePad_16b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/8Bitdo_Zero_GamePad_16b_8a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="8Bitdo Zero GamePad" provider="linux" buttoncount="16" axiscount="8">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="10" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="10"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/DragonRise_Inc._Generic_USB_Joystick_12b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/DragonRise_Inc._Generic_USB_Joystick_12b_6a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="DragonRise Inc.   Generic   USB  Joystick" provider="linux" buttoncount="12" axiscount="6">
         <controller id="game.controller.default">
-            <feature name="a" button="2" />
-            <feature name="b" button="3" />
-            <feature name="back" button="4" />
-            <feature name="down" axis="+5" />
-            <feature name="left" axis="-4" />
-            <feature name="leftbumper" button="6" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="3"/>
+            <feature name="back" button="4"/>
+            <feature name="down" axis="+5"/>
+            <feature name="left" axis="-4"/>
+            <feature name="leftbumper" button="6"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="8" />
-            <feature name="right" axis="+4" />
-            <feature name="rightbumper" button="7" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="8"/>
+            <feature name="right" axis="+4"/>
+            <feature name="rightbumper" button="7"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="9" />
-            <feature name="start" button="5" />
-            <feature name="up" axis="-5" />
-            <feature name="x" button="0" />
-            <feature name="y" button="1" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="9"/>
+            <feature name="start" button="5"/>
+            <feature name="up" axis="-5"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="1"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/DualSense_Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/DualSense_Wireless_Controller_13b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="DualSense Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="10" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="11" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="10"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l3" button="11"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="12" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="12"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" axis="-7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="3"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="2"/>
+            <feature name="up" axis="-7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Dual_PSX-USB_Adaptor_Dual_PSX-USB_Adaptor_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Dual_PSX-USB_Adaptor_Dual_PSX-USB_Adaptor_16b_4a.xml
@@ -1,37 +1,37 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Dual PSX-USB Adaptor  Dual PSX-USB Adaptor" provider="linux" buttoncount="16" axiscount="4">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="b" button="1" />
-            <feature name="back" button="8" />
-            <feature name="down" button="14" />
-            <feature name="left" button="15" />
-            <feature name="leftbumper" button="4" />
+            <feature name="b" button="1"/>
+            <feature name="back" button="8"/>
+            <feature name="down" button="14"/>
+            <feature name="left" button="15"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="6" />
-            <feature name="lefttrigger" button="10" />
-            <feature name="right" button="13" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="6"/>
+            <feature name="lefttrigger" button="10"/>
+            <feature name="right" button="13"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-2" />
-                <down axis="+2" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-2"/>
+                <down axis="+2"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="7" />
-            <feature name="righttrigger" button="11" />
-            <feature name="start" button="9" />
-            <feature name="up" button="12" />
-            <feature name="x" button="3" />
-            <feature name="y" button="0" />
+            <feature name="rightthumb" button="7"/>
+            <feature name="righttrigger" button="11"/>
+            <feature name="start" button="9"/>
+            <feature name="up" button="12"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="0"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/GPIO_Controller_1_9b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/GPIO_Controller_1_9b_2a.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="GPIO Controller 1" provider="linux" buttoncount="9" axiscount="2">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+1" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-0" />
-            <feature name="lefttrigger" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="righttrigger" button="5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+1"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-0"/>
+            <feature name="lefttrigger" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="righttrigger" button="5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/GPIO_Controller_2_9b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/GPIO_Controller_2_9b_2a.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="GPIO Controller 2" provider="linux" buttoncount="9" axiscount="2">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+1" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-0" />
-            <feature name="lefttrigger" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="righttrigger" button="5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+1"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-0"/>
+            <feature name="lefttrigger" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="righttrigger" button="5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Gamepad_17b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Gamepad_17b_8a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Gamepad" provider="linux" buttoncount="17" axiscount="8">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="10" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="6" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="10"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="6"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="13" />
-            <feature name="lefttrigger" button="8" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="7" />
+            <feature name="leftthumb" button="13"/>
+            <feature name="lefttrigger" button="8"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="7"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="14" />
-            <feature name="righttrigger" button="9" />
-            <feature name="start" button="11" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="rightthumb" button="14"/>
+            <feature name="righttrigger" button="9"/>
+            <feature name="start" button="11"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Generic_USB_Joystick_12b_7a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Generic_USB_Joystick_12b_7a.xml
@@ -1,28 +1,28 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Generic   USB  Joystick" provider="linux" buttoncount="12" axiscount="7">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.n64">
-            <feature name="a" button="6" />
+            <feature name="a" button="6"/>
             <feature name="analogstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="8" />
-            <feature name="cdown" button="2" />
-            <feature name="cleft" button="3" />
-            <feature name="cright" button="1" />
-            <feature name="cup" button="0" />
-            <feature name="down" axis="+6" />
-            <feature name="left" axis="-5" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+5" />
-            <feature name="rightbumper" button="5" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-6" />
-            <feature name="z" button="7" />
+            <feature name="b" button="8"/>
+            <feature name="cdown" button="2"/>
+            <feature name="cleft" button="3"/>
+            <feature name="cright" button="1"/>
+            <feature name="cup" button="0"/>
+            <feature name="down" axis="+6"/>
+            <feature name="left" axis="-5"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+5"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-6"/>
+            <feature name="z" button="7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Generic_X-Box_pad_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Generic_X-Box_pad_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Generic X-Box pad" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Generic___USB__Joystick___12b_7a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Generic___USB__Joystick___12b_7a.xml
@@ -1,30 +1,30 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Generic   USB  Joystick  " provider="linux" buttoncount="12" axiscount="7">
         <configuration>
-            <appearance id="game.controller.n64" />
+            <appearance id="game.controller.n64"/>
         </configuration>
         <controller id="game.controller.n64">
-            <feature name="a" button="6" />
+            <feature name="a" button="6"/>
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="8" />
-            <feature name="cdown" button="2" />
-            <feature name="cleft" button="3" />
-            <feature name="cright" button="1" />
-            <feature name="cup" button="0" />
-            <feature name="down" axis="+6" />
-            <feature name="left" axis="-5" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+5" />
-            <feature name="rightbumper" button="5" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-6" />
-            <feature name="z" button="7" />
+            <feature name="b" button="8"/>
+            <feature name="cdown" button="2"/>
+            <feature name="cleft" button="3"/>
+            <feature name="cright" button="1"/>
+            <feature name="cup" button="0"/>
+            <feature name="down" axis="+6"/>
+            <feature name="left" axis="-5"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+5"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-6"/>
+            <feature name="z" button="7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Gravis_GamePad_Pro_USB_10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Gravis_GamePad_Pro_USB_10b_2a.xml
@@ -1,21 +1,21 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Gravis GamePad Pro USB" provider="linux" buttoncount="10" axiscount="2">
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="5" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/GreenAsia_Inc._USB_Joystick_12b_7a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/GreenAsia_Inc._USB_Joystick_12b_7a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="GreenAsia Inc.    USB Joystick" provider="linux" buttoncount="12" axiscount="7">
         <controller id="game.controller.default">
-            <feature name="a" button="2" />
-            <feature name="b" button="3" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+5" />
-            <feature name="left" axis="-4" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="3"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+5"/>
+            <feature name="left" axis="-4"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+4" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+4"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-2" />
-                <down axis="+2" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-2"/>
+                <down axis="+2"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-5" />
-            <feature name="x" button="0" />
-            <feature name="y" button="1" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-5"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="1"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/HID_6666_0667_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/HID_6666_0667_16b_4a.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="HID 6666:0667" provider="linux" buttoncount="16" axiscount="4">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/HuiJia__USB_GamePad_16b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/HuiJia__USB_GamePad_16b_6a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="HuiJia  USB GamePad" provider="linux" buttoncount="16" axiscount="6">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Gamepad_F310_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Gamepad_F310_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Logitech Gamepad F310" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Inc._WingMan_RumblePad_9b_7a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Inc._WingMan_RumblePad_9b_7a.xml
@@ -1,31 +1,31 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Logitech Inc. WingMan RumblePad" provider="linux" buttoncount="9" axiscount="7">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="2" />
-            <feature name="down" axis="+6" />
-            <feature name="left" axis="-5" />
-            <feature name="leftbumper" button="6" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="2"/>
+            <feature name="down" axis="+6"/>
+            <feature name="left" axis="-5"/>
+            <feature name="leftbumper" button="6"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="right" axis="+5" />
-            <feature name="rightbumper" button="7" />
+            <feature name="right" axis="+5"/>
+            <feature name="rightbumper" button="7"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="start" button="8" />
-            <feature name="up" axis="-6" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="start" button="8"/>
+            <feature name="up" axis="-6"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Logitech_Dual_Action_12b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Logitech_Dual_Action_12b_6a.xml
@@ -1,36 +1,36 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Logitech Logitech Dual Action" provider="linux" buttoncount="12" axiscount="6">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+5" />
-            <feature name="left" axis="-4" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+5"/>
+            <feature name="left" axis="-4"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+4" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+4"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-5" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-5"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Logitech_RumblePad_2_USB_12b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Logitech_Logitech_RumblePad_2_USB_12b_6a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Logitech Logitech RumblePad 2 USB" provider="linux" buttoncount="12" axiscount="6">
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+5" />
-            <feature name="left" axis="-4" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+5"/>
+            <feature name="left" axis="-4"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+4" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+4"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-5" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-5"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/MY-POWER_CO._LTD._2In1_USB_Joystick_12b_7a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/MY-POWER_CO._LTD._2In1_USB_Joystick_12b_7a.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="MY-POWER CO.,LTD. 2In1 USB Joystick" provider="linux" buttoncount="12" axiscount="7">
         <controller id="game.controller.default">
-            <feature name="a" button="2" />
-            <feature name="b" button="1" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+5" />
-            <feature name="left" axis="-4" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+5"/>
+            <feature name="left" axis="-4"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+4" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+4"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-5" />
-            <feature name="x" button="3" />
-            <feature name="y" button="0" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-5"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="0"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_0_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_0_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad 0" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_11b_8a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_1_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_1_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad 1" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_2_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_2_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad 2" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_3_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_360_pad_3_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad 3" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_Elite_2_pad_15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_Elite_2_pad_15b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box One Elite 2 pad" provider="linux" buttoncount="15" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />            
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>            
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" /> 
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/> 
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_Elite_pad_15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_Elite_pad_15b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box One Elite pad" provider="linux" buttoncount="15" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_S_pad_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_S_pad_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box One S pad" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad_11b_8a.xml
@@ -1,723 +1,723 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box One pad" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.3do">
-            <feature name="a" button="2" />
-            <feature name="b" button="0" />
-            <feature name="c" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="play" button="7" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="stop" button="6" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="0"/>
+            <feature name="c" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="play" button="7"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="stop" button="6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.amiga.cd32">
-            <feature name="blue" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="forward" button="5" />
-            <feature name="green" button="2" />
-            <feature name="left" axis="-6" />
-            <feature name="play" button="7" />
-            <feature name="red" button="0" />
-            <feature name="rewind" button="4" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
-            <feature name="yellow" button="3" />
+            <feature name="blue" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="forward" button="5"/>
+            <feature name="green" button="2"/>
+            <feature name="left" axis="-6"/>
+            <feature name="play" button="7"/>
+            <feature name="red" button="0"/>
+            <feature name="rewind" button="4"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
+            <feature name="yellow" button="3"/>
         </controller>
         <controller id="game.controller.amstrad.joystick">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.arcade.neogeo">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="c" button="2" />
-            <feature name="d" button="3" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="select" button="6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="c" button="2"/>
+            <feature name="d" button="3"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="select" button="6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.atari.2600">
-            <feature name="down" axis="+7" />
-            <feature name="fire" button="0" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="down" axis="+7"/>
+            <feature name="fire" button="0"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.atari.7800.gamepad">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.atari.7800.proline">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.atari.lynx">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="option1" button="7" />
-            <feature name="option2" button="6" />
-            <feature name="pause" button="2" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="option1" button="7"/>
+            <feature name="option2" button="6"/>
+            <feature name="pause" button="2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
         <controller id="game.controller.dreamcast">
-            <feature name="a" button="0" />
+            <feature name="a" button="0"/>
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
         <controller id="game.controller.gameboy">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="select" button="6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="select" button="6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.gamecube">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
             <feature name="controlstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="cstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="down" axis="+7" />
-            <feature name="l" axis="+2" />
-            <feature name="left" axis="-6" />
-            <feature name="r" axis="+5" />
-            <feature name="right" axis="+6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="2" />
-            <feature name="z" button="5" />
+            <feature name="down" axis="+7"/>
+            <feature name="l" axis="+2"/>
+            <feature name="left" axis="-6"/>
+            <feature name="r" axis="+5"/>
+            <feature name="right" axis="+6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="2"/>
+            <feature name="z" button="5"/>
         </controller>
         <controller id="game.controller.gamegear">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.gba">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="select" button="6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="select" button="6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.genesis.3button">
-            <feature name="a" button="2" />
-            <feature name="b" button="0" />
-            <feature name="c" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="mode" button="6" />
-            <feature name="right" axis="+6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="2"/>
+            <feature name="b" button="0"/>
+            <feature name="c" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="mode" button="6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.genesis.6button">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="c" button="5" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="mode" button="6" />
-            <feature name="right" axis="+6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
-            <feature name="z" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="c" button="5"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="mode" button="6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="4"/>
         </controller>
         <controller id="game.controller.gravis.gamepad">
-            <feature name="blue" button="3" />
-            <feature name="down" axis="+7" />
-            <feature name="green" button="1" />
-            <feature name="left" axis="-6" />
-            <feature name="red" button="2" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
-            <feature name="yellow" button="0" />
+            <feature name="blue" button="3"/>
+            <feature name="down" axis="+7"/>
+            <feature name="green" button="1"/>
+            <feature name="left" axis="-6"/>
+            <feature name="red" button="2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
+            <feature name="yellow" button="0"/>
         </controller>
         <controller id="game.controller.joystick.2button">
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
         </controller>
         <controller id="game.controller.joystick.4button">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="button3" button="2" />
-            <feature name="button4" button="3" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="button3" button="2"/>
+            <feature name="button4" button="3"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
         </controller>
         <controller id="game.controller.msx.joystick">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.n64">
-            <feature name="a" button="0" />
+            <feature name="a" button="0"/>
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="2" />
-            <feature name="cdown" axis="+4" />
-            <feature name="cleft" axis="-3" />
-            <feature name="cright" axis="+3" />
-            <feature name="cup" axis="-4" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="z" axis="+2" />
+            <feature name="b" button="2"/>
+            <feature name="cdown" axis="+4"/>
+            <feature name="cleft" axis="-3"/>
+            <feature name="cright" axis="+3"/>
+            <feature name="cup" axis="-4"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="z" axis="+2"/>
         </controller>
         <controller id="game.controller.nds">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="layout" button="9" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="lid" button="10" />
-            <feature name="microphone" button="8" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="layout" button="9"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="lid" button="10"/>
+            <feature name="microphone" button="8"/>
             <feature name="pointer">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="select" button="6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="2" />
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="select" button="6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="2"/>
         </controller>
         <controller id="game.controller.nes">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="select" button="6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="select" button="6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.ngp">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="option" button="7" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="option" button="7"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.odyssey2">
-            <feature name="action" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="action" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.ouya">
-            <feature name="a" button="0" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="1" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="1"/>
         </controller>
         <controller id="game.controller.pcfx">
-            <feature name="down" axis="+7" />
-            <feature name="i" button="5" />
-            <feature name="ii" button="1" />
-            <feature name="iii" button="0" />
-            <feature name="iv" button="4" />
-            <feature name="left" axis="-6" />
-            <feature name="mode1" button="9" />
-            <feature name="mode2" button="10" />
-            <feature name="right" axis="+6" />
-            <feature name="run" button="7" />
-            <feature name="select" button="6" />
-            <feature name="up" axis="-7" />
-            <feature name="v" button="3" />
-            <feature name="vi" button="2" />
+            <feature name="down" axis="+7"/>
+            <feature name="i" button="5"/>
+            <feature name="ii" button="1"/>
+            <feature name="iii" button="0"/>
+            <feature name="iv" button="4"/>
+            <feature name="left" axis="-6"/>
+            <feature name="mode1" button="9"/>
+            <feature name="mode2" button="10"/>
+            <feature name="right" axis="+6"/>
+            <feature name="run" button="7"/>
+            <feature name="select" button="6"/>
+            <feature name="up" axis="-7"/>
+            <feature name="v" button="3"/>
+            <feature name="vi" button="2"/>
         </controller>
         <controller id="game.controller.pokemini">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="c" button="5" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="power" button="7" />
-            <feature name="right" axis="+6" />
-            <feature name="shake" button="4" />
-            <feature name="up" axis="-7" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="c" button="5"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="power" button="7"/>
+            <feature name="right" axis="+6"/>
+            <feature name="shake" button="4"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="8" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="9" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="8"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l3" button="9"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="10" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="10"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="6" />
-            <feature name="square" button="2" />
-            <feature name="start" button="7" />
-            <feature name="triangle" button="3" />
-            <feature name="up" axis="-7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="6"/>
+            <feature name="square" button="2"/>
+            <feature name="start" button="7"/>
+            <feature name="triangle" button="3"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.ps.dualshock">
-            <feature name="analog" button="8" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="9" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="8"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l3" button="9"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="10" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="10"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="6" />
-            <feature name="square" button="2" />
-            <feature name="start" button="7" />
-            <feature name="triangle" button="3" />
-            <feature name="up" axis="-7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="6"/>
+            <feature name="square" button="2"/>
+            <feature name="start" button="7"/>
+            <feature name="triangle" button="3"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.ps.gamepad">
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="6" />
-            <feature name="square" button="2" />
-            <feature name="start" button="7" />
-            <feature name="triangle" button="3" />
-            <feature name="up" axis="-7" />
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="6"/>
+            <feature name="square" button="2"/>
+            <feature name="start" button="7"/>
+            <feature name="triangle" button="3"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.psp">
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l" button="4" />
-            <feature name="left" axis="-6" />
-            <feature name="r" button="5" />
-            <feature name="right" axis="+6" />
-            <feature name="select" button="6" />
-            <feature name="square" button="2" />
-            <feature name="start" button="7" />
-            <feature name="triangle" button="3" />
-            <feature name="up" axis="-7" />
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l" button="4"/>
+            <feature name="left" axis="-6"/>
+            <feature name="r" button="5"/>
+            <feature name="right" axis="+6"/>
+            <feature name="select" button="6"/>
+            <feature name="square" button="2"/>
+            <feature name="start" button="7"/>
+            <feature name="triangle" button="3"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.remote">
-            <feature name="back" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="home" button="3" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="select" button="0" />
-            <feature name="up" axis="-7" />
+            <feature name="back" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="home" button="3"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="select" button="0"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.saturn">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="c" button="5" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
-            <feature name="z" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="c" button="5"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="4"/>
         </controller>
         <controller id="game.controller.saturn.3d.japan">
-            <feature name="a" button="0" />
+            <feature name="a" button="0"/>
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="1" />
-            <feature name="c" button="5" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
-            <feature name="z" button="4" />
+            <feature name="b" button="1"/>
+            <feature name="c" button="5"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="4"/>
         </controller>
         <controller id="game.controller.saturn.3d.western">
-            <feature name="a" button="0" />
+            <feature name="a" button="0"/>
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="1" />
-            <feature name="c" button="5" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
-            <feature name="z" button="4" />
+            <feature name="b" button="1"/>
+            <feature name="c" button="5"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="4"/>
         </controller>
         <controller id="game.controller.saturn.arcade.racer">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="c" button="5" />
-            <feature name="leftshift" button="9" />
-            <feature name="rightshift" button="10" />
-            <feature name="start" button="7" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="c" button="5"/>
+            <feature name="leftshift" button="9"/>
+            <feature name="rightshift" button="10"/>
+            <feature name="start" button="7"/>
             <feature name="wheel">
-                <left axis="-0" />
-                <right axis="+0" />
+                <left axis="-0"/>
+                <right axis="+0"/>
             </feature>
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
-            <feature name="z" button="4" />
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="4"/>
         </controller>
         <controller id="game.controller.saturn.mission.stick">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="c" button="5" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="c" button="5"/>
             <feature name="joystick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="l" axis="+2" />
-            <feature name="r" axis="+5" />
-            <feature name="start" button="7" />
+            <feature name="l" axis="+2"/>
+            <feature name="r" axis="+5"/>
+            <feature name="start" button="7"/>
             <feature name="throttle">
-                <up axis="-4" />
-                <down axis="+4" />
+                <up axis="-4"/>
+                <down axis="+4"/>
             </feature>
-            <feature name="throttlelatch" button="10" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
-            <feature name="z" button="4" />
+            <feature name="throttlelatch" button="10"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="4"/>
         </controller>
         <controller id="game.controller.saturn.mission.sticks">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="c" button="5" />
-            <feature name="l" axis="+2" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="c" button="5"/>
+            <feature name="l" axis="+2"/>
             <feature name="leftjoystick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="r" axis="+5" />
+            <feature name="r" axis="+5"/>
             <feature name="rightjoystick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="start" button="7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
-            <feature name="z" button="4" />
+            <feature name="start" button="7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="4"/>
         </controller>
         <controller id="game.controller.saturn.twin.stick">
-            <feature name="leftbutton" button="4" />
+            <feature name="leftbutton" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="rightbutton" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="rightbutton" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
         </controller>
         <controller id="game.controller.sg1000">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.sms">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
-            <feature name="select" button="6" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="2" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="select" button="6"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="2"/>
         </controller>
         <controller id="game.controller.vb">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="leftdown" axis="+4" />
-            <feature name="leftleft" axis="-3" />
-            <feature name="leftright" axis="+3" />
-            <feature name="leftup" axis="-4" />
-            <feature name="rightbumper" button="5" />
-            <feature name="rightdown" axis="+1" />
-            <feature name="rightleft" axis="-0" />
-            <feature name="rightright" axis="+0" />
-            <feature name="rightup" axis="-1" />
-            <feature name="select" button="6" />
-            <feature name="start" button="7" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="leftdown" axis="+4"/>
+            <feature name="leftleft" axis="-3"/>
+            <feature name="leftright" axis="+3"/>
+            <feature name="leftup" axis="-4"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="rightdown" axis="+1"/>
+            <feature name="rightleft" axis="-0"/>
+            <feature name="rightright" axis="+0"/>
+            <feature name="rightup" axis="-1"/>
+            <feature name="select" button="6"/>
+            <feature name="start" button="7"/>
         </controller>
         <controller id="game.controller.vectrex">
-            <feature name="button1" button="0" />
-            <feature name="button2" button="1" />
-            <feature name="button3" button="2" />
-            <feature name="button4" button="3" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="right" axis="+6" />
-            <feature name="up" axis="-7" />
+            <feature name="button1" button="0"/>
+            <feature name="button2" button="1"/>
+            <feature name="button3" button="2"/>
+            <feature name="button4" button="3"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.wiimote">
-            <feature name="a" button="0" />
-            <feature name="b" axis="+5" />
-            <feature name="down" axis="+7" />
-            <feature name="home" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="minus" button="6" />
-            <feature name="one" button="2" />
-            <feature name="plus" button="7" />
+            <feature name="a" button="0"/>
+            <feature name="b" axis="+5"/>
+            <feature name="down" axis="+7"/>
+            <feature name="home" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="minus" button="6"/>
+            <feature name="one" button="2"/>
+            <feature name="plus" button="7"/>
             <feature name="pointer">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="right" axis="+6" />
-            <feature name="two" button="3" />
-            <feature name="up" axis="-7" />
+            <feature name="right" axis="+6"/>
+            <feature name="two" button="3"/>
+            <feature name="up" axis="-7"/>
         </controller>
         <controller id="game.controller.ws">
-            <feature name="a" button="1" />
-            <feature name="b" button="0" />
-            <feature name="start" button="7" />
-            <feature name="xdown" axis="+1" />
-            <feature name="xleft" axis="-0" />
-            <feature name="xright" axis="+0" />
-            <feature name="xup" axis="-1" />
-            <feature name="ydown" axis="+4" />
-            <feature name="yleft" axis="-3" />
-            <feature name="yright" axis="+3" />
-            <feature name="yup" axis="-4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="0"/>
+            <feature name="start" button="7"/>
+            <feature name="xdown" axis="+1"/>
+            <feature name="xleft" axis="-0"/>
+            <feature name="xright" axis="+0"/>
+            <feature name="xup" axis="-1"/>
+            <feature name="ydown" axis="+4"/>
+            <feature name="yleft" axis="-3"/>
+            <feature name="yright" axis="+3"/>
+            <feature name="yup" axis="-4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad_12b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad_12b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box One pad" provider="linux" buttoncount="12" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad__Firmware_2015__11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_X-Box_One_pad__Firmware_2015__11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box One pad (Firmware 2015)" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_Xbox_Series_S_X_Controller_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Microsoft_Xbox_Series_S_X_Controller_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft Xbox Series S|X Controller" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/NVIDIA_Corporation_NVIDIA_Controller_v01.03_14b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/NVIDIA_Corporation_NVIDIA_Controller_v01.03_14b_8a.xml
@@ -1,34 +1,34 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="NVIDIA Corporation NVIDIA Controller v01.03" provider="linux" buttoncount="14" axiscount="8">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+7" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+7"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="8" />
-            <feature name="lefttrigger" axis="+5" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="8"/>
+            <feature name="lefttrigger" axis="+5"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <up axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <up axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="9" />
-            <feature name="righttrigger" axis="+4" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="9"/>
+            <feature name="righttrigger" axis="+4"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/PLAYSTATION_R_3_Controller.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/PLAYSTATION_R_3_Controller.xml
@@ -1,40 +1,40 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <!-- Sony Playstation 3 Controller connected through the Bluez 5 sixaxis plugin. -->
     <device name="PLAYSTATION(R)3 Controller" provider="linux" buttoncount="19" axiscount="27">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="14" />
-            <feature name="b" button="13" />
-            <feature name="back" button="0" />
-            <feature name="down" button="6" />
-            <feature name="guide" button="16" />
-            <feature name="left" button="7" />
-            <feature name="leftbumper" button="10" />
+            <feature name="a" button="14"/>
+            <feature name="b" button="13"/>
+            <feature name="back" button="0"/>
+            <feature name="down" button="6"/>
+            <feature name="guide" button="16"/>
+            <feature name="left" button="7"/>
+            <feature name="leftbumper" button="10"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="1" />
-            <feature name="lefttrigger" button="8" />
-            <feature name="right" button="5" />
-            <feature name="rightbumper" button="11" />
+            <feature name="leftthumb" button="1"/>
+            <feature name="lefttrigger" button="8"/>
+            <feature name="right" button="5"/>
+            <feature name="rightbumper" button="11"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="2" />
-            <feature name="righttrigger" button="9" />
-            <feature name="start" button="3" />
-            <feature name="up" button="4" />
-            <feature name="x" button="15" />
-            <feature name="y" button="12" />
+            <feature name="rightthumb" button="2"/>
+            <feature name="righttrigger" button="9"/>
+            <feature name="start" button="3"/>
+            <feature name="up" button="4"/>
+            <feature name="x" button="15"/>
+            <feature name="y" button="12"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/PLAYSTATION_R_3_Controller_17b_29a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/PLAYSTATION_R_3_Controller_17b_29a.xml
@@ -1,40 +1,40 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <!-- Sony Playstation 3 Controller connected through QtSixA (sixpair, sixad). -->
     <device name="PLAYSTATION(R)3 Controller" provider="linux" buttoncount="17" axiscount="29">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="14" />
-            <feature name="b" button="13" />
-            <feature name="back" button="0" />
-            <feature name="down" button="6" />
-            <feature name="guide" button="16" />
-            <feature name="left" button="7" />
-            <feature name="leftbumper" button="10" />
+            <feature name="a" button="14"/>
+            <feature name="b" button="13"/>
+            <feature name="back" button="0"/>
+            <feature name="down" button="6"/>
+            <feature name="guide" button="16"/>
+            <feature name="left" button="7"/>
+            <feature name="leftbumper" button="10"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="1" />
-            <feature name="lefttrigger" button="8" />
-            <feature name="right" button="5" />
-            <feature name="rightbumper" button="11" />
+            <feature name="leftthumb" button="1"/>
+            <feature name="lefttrigger" button="8"/>
+            <feature name="right" button="5"/>
+            <feature name="rightbumper" button="11"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="2" />
-            <feature name="righttrigger" button="9" />
-            <feature name="start" button="3" />
-            <feature name="up" button="4" />
-            <feature name="x" button="15" />
-            <feature name="y" button="12" />
+            <feature name="rightthumb" button="2"/>
+            <feature name="righttrigger" button="9"/>
+            <feature name="start" button="3"/>
+            <feature name="up" button="4"/>
+            <feature name="x" button="15"/>
+            <feature name="y" button="12"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Parallels_Virtual_Mouse_8b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Parallels_Virtual_Mouse_8b_2a.xml
@@ -1,10 +1,10 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Parallels Virtual Mouse" provider="linux" buttoncount="8" axiscount="2">
         <configuration>
-            <appearance id="game.controller.mouse" />
-            <button index="0" ignore="true" />
-            <button index="1" ignore="true" />
+            <appearance id="game.controller.mouse"/>
+            <button index="0" ignore="true"/>
+            <button index="1" ignore="true"/>
         </configuration>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Pro_Controller_16b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Pro_Controller_16b_6a.xml
@@ -1,31 +1,31 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Pro Controller" provider="linux" buttoncount="16" axiscount="6">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+5" />
-            <feature name="guide" button="12" />
-            <feature name="left" axis="-4" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+5"/>
+            <feature name="guide" button="12"/>
+            <feature name="left" axis="-4"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+4" />
-            <feature name="rightbumper" button="5" />
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-5" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+4"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-5"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/ShanWan_PS_R__Ga_epad_17b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/ShanWan_PS_R__Ga_epad_17b_6a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="ShanWan PS(R) Ga`epad" provider="linux" buttoncount="17" axiscount="6">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="10" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" button="14" />
-            <feature name="l3" button="11" />
-            <feature name="left" button="15" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="10"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" button="14"/>
+            <feature name="l3" button="11"/>
+            <feature name="left" button="15"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="12" />
-            <feature name="right" button="16" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="12"/>
+            <feature name="right" button="16"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" button="13" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="3"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="2"/>
+            <feature name="up" button="13"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/ShanWan_PS_R__Ga_epad_19b_27a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/ShanWan_PS_R__Ga_epad_19b_27a.xml
@@ -1,48 +1,48 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="ShanWan PS(R) Ga`epad" provider="linux" buttoncount="19" axiscount="27">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="12" center="-1" range="2" />
-            <axis index="13" center="-1" range="2" />
-            <axis index="14" center="-1" range="2" />
-            <axis index="15" center="-1" range="2" />
-            <axis index="16" center="-1" range="1" />
-            <axis index="17" center="-1" range="2" />
-            <axis index="18" center="-1" range="1" />
-            <button index="8" ignore="true" />
-            <button index="9" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="12" center="-1" range="2"/>
+            <axis index="13" center="-1" range="2"/>
+            <axis index="14" center="-1" range="2"/>
+            <axis index="15" center="-1" range="2"/>
+            <axis index="16" center="-1" range="1"/>
+            <axis index="17" center="-1" range="2"/>
+            <axis index="18" center="-1" range="1"/>
+            <button index="8" ignore="true"/>
+            <button index="9" ignore="true"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="14" />
-            <feature name="b" button="13" />
-            <feature name="back" button="0" />
-            <feature name="down" button="6" />
-            <feature name="guide" button="16" />
-            <feature name="left" button="17" />
-            <feature name="leftbumper" button="10" />
+            <feature name="a" button="14"/>
+            <feature name="b" button="13"/>
+            <feature name="back" button="0"/>
+            <feature name="down" button="6"/>
+            <feature name="guide" button="16"/>
+            <feature name="left" button="17"/>
+            <feature name="leftbumper" button="10"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="1" />
-            <feature name="lefttrigger" axis="+12" />
-            <feature name="right" button="5" />
-            <feature name="rightbumper" button="11" />
+            <feature name="leftthumb" button="1"/>
+            <feature name="lefttrigger" axis="+12"/>
+            <feature name="right" button="5"/>
+            <feature name="rightbumper" button="11"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="2" />
-            <feature name="righttrigger" axis="+13" />
-            <feature name="start" button="3" />
-            <feature name="up" button="4" />
-            <feature name="x" button="15" />
-            <feature name="y" button="12" />
+            <feature name="rightthumb" button="2"/>
+            <feature name="righttrigger" axis="+13"/>
+            <feature name="start" button="3"/>
+            <feature name="up" button="4"/>
+            <feature name="x" button="15"/>
+            <feature name="y" button="12"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Computer_Entertainment_Wireless_Controller_14b_18a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Computer_Entertainment_Wireless_Controller_14b_18a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony Computer Entertainment Wireless Controller" provider="linux" buttoncount="14" axiscount="18">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="12" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="12"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-5" />
-                <down axis="+5" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-5"/>
+                <down axis="+5"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_DualSense_Wireless__13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_DualSense_Wireless__13b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony Interactive Entertainment DualSense Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="10" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="11" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="10"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l3" button="11"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="12" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="12"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" axis="-7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="3"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="2"/>
+            <feature name="up" axis="-7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_Wireless_Controller_13b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony Interactive Entertainment Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="10" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="11" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="10"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l3" button="11"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="12" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="12"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" axis="-7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="3"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="2"/>
+            <feature name="up" axis="-7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_Wireless_Controller_14b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_Interactive_Entertainment_Wireless_Controller_14b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony Interactive Entertainment Wireless Controller" provider="linux" buttoncount="14" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="3" center="-1" range="2" />
-            <axis index="4" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="3" center="-1" range="2"/>
+            <axis index="4" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="13" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="13"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" axis="+3" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" axis="+3"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-5" />
-                <down axis="+5" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-5"/>
+                <down axis="+5"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" axis="+4" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" axis="+4"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_PLAYSTATION_R_3_Controller_17b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_PLAYSTATION_R_3_Controller_17b_6a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony PLAYSTATION(R)3 Controller" provider="linux" buttoncount="17" axiscount="6">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="8" />
-            <feature name="down" button="14" />
-            <feature name="guide" button="10" />
-            <feature name="left" button="15" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="8"/>
+            <feature name="down" button="14"/>
+            <feature name="guide" button="10"/>
+            <feature name="left" button="15"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="11" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="16" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="11"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="16"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="12" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="9" />
-            <feature name="up" button="13" />
-            <feature name="x" button="3" />
-            <feature name="y" button="2" />
+            <feature name="rightthumb" button="12"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="9"/>
+            <feature name="up" button="13"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="2"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_PLAYSTATION_R_3_Controller_19b_27a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Sony_PLAYSTATION_R_3_Controller_19b_27a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony PLAYSTATION(R)3 Controller" provider="linux" buttoncount="19" axiscount="27">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="14" />
-            <feature name="b" button="13" />
-            <feature name="back" button="0" />
-            <feature name="down" button="6" />
-            <feature name="guide" button="16" />
-            <feature name="left" button="7" />
-            <feature name="leftbumper" button="10" />
+            <feature name="a" button="14"/>
+            <feature name="b" button="13"/>
+            <feature name="back" button="0"/>
+            <feature name="down" button="6"/>
+            <feature name="guide" button="16"/>
+            <feature name="left" button="7"/>
+            <feature name="leftbumper" button="10"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="1" />
-            <feature name="lefttrigger" button="8" />
-            <feature name="right" button="5" />
-            <feature name="rightbumper" button="11" />
+            <feature name="leftthumb" button="1"/>
+            <feature name="lefttrigger" button="8"/>
+            <feature name="right" button="5"/>
+            <feature name="rightbumper" button="11"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="2" />
-            <feature name="righttrigger" button="9" />
-            <feature name="start" button="3" />
-            <feature name="up" button="4" />
-            <feature name="x" button="15" />
-            <feature name="y" button="12" />
+            <feature name="rightthumb" button="2"/>
+            <feature name="righttrigger" button="9"/>
+            <feature name="start" button="3"/>
+            <feature name="up" button="4"/>
+            <feature name="x" button="15"/>
+            <feature name="y" button="12"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/USB_Gamepad_10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/USB_Gamepad_10b_2a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="USB Gamepad" provider="linux" buttoncount="10" axiscount="2">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="5" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_13b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Wireless Controller" provider="linux" buttoncount="13" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="10" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="10"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="11" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="11"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="12" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="3" />
-            <feature name="y" button="2" />
+            <feature name="rightthumb" button="12"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="2"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_14b_18a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_14b_18a.xml
@@ -1,37 +1,37 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Wireless Controller" provider="linux" buttoncount="14" axiscount="18">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="12" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="12"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-5" />
-                <down axis="+5" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-5"/>
+                <down axis="+5"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_14b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wireless_Controller_14b_8a.xml
@@ -1,36 +1,36 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Wireless Controller" provider="linux" buttoncount="14" axiscount="8">
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="12" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="12"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-5" />
-                <down axis="+5" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-5"/>
+                <down axis="+5"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Wish_Technologies_Adaptoid_14b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Wish_Technologies_Adaptoid_14b_2a.xml
@@ -1,30 +1,30 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Wish Technologies Adaptoid" provider="linux" buttoncount="14" axiscount="2">
         <configuration>
-            <appearance id="game.controller.n64" />
+            <appearance id="game.controller.n64"/>
         </configuration>
         <controller id="game.controller.n64">
-            <feature name="a" button="0" />
+            <feature name="a" button="0"/>
             <feature name="analogstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="b" button="3" />
-            <feature name="cdown" button="1" />
-            <feature name="cleft" button="4" />
-            <feature name="cright" button="2" />
-            <feature name="cup" button="5" />
-            <feature name="down" button="11" />
-            <feature name="left" button="12" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" button="13" />
-            <feature name="rightbumper" button="7" />
-            <feature name="start" button="8" />
-            <feature name="up" button="10" />
-            <feature name="z" button="9" />
+            <feature name="b" button="3"/>
+            <feature name="cdown" button="1"/>
+            <feature name="cleft" button="4"/>
+            <feature name="cright" button="2"/>
+            <feature name="cup" button="5"/>
+            <feature name="down" button="11"/>
+            <feature name="left" button="12"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" button="13"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="10"/>
+            <feature name="z" button="9"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_15b_6a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver" provider="linux" buttoncount="15" axiscount="6">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="14" />
-            <feature name="guide" button="8" />
-            <feature name="left" button="11" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="14"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" button="11"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="12" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="12"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="13" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="13"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_15b_8a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver" provider="linux" buttoncount="15" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="14" />
-            <feature name="guide" button="8" />
-            <feature name="left" button="11" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="14"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" button="11"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="12" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="12"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="13" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="13"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_XBOX_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_XBOX_15b_6a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver (XBOX)" provider="linux" buttoncount="15" axiscount="6">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="14" />
-            <feature name="guide" button="8" />
-            <feature name="left" button="11" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="14"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" button="11"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="12" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="12"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="13" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="13"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_XBOX_15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver_XBOX_15b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver (XBOX)" provider="linux" buttoncount="15" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="14" />
-            <feature name="guide" button="8" />
-            <feature name="left" button="11" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="14"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" button="11"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="12" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="12"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="13" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="13"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver__XBOX__15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_360_Wireless_Receiver__XBOX__15b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver (XBOX)" provider="linux" buttoncount="15" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="14" />
-            <feature name="guide" button="8" />
-            <feature name="left" button="11" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="14"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" button="11"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="12" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="12"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="13" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="13"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_Elite_Wireless_Controller_15b_9a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_Elite_Wireless_Controller_15b_9a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox Elite Wireless Controller" provider="linux" buttoncount="15" axiscount="9">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_One_Wireless_Controller_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_One_Wireless_Controller_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox One Wireless Controller" provider="linux" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_Wireless_Controller_15b_9a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/Xbox_Wireless_Controller_15b_9a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox Wireless Controller" provider="linux" buttoncount="15" axiscount="9">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/mayflash_limited_MAYFLASH_GameCube_Controller_Adap_16b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/mayflash_limited_MAYFLASH_GameCube_Controller_Adap_16b_8a.xml
@@ -1,38 +1,38 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="mayflash limited MAYFLASH GameCube Controller Adapter" provider="linux" buttoncount="16" axiscount="8">
         <configuration>
-            <appearance id="game.controller.gamecube" />
-            <axis index="3" center="-1" range="2" />
-            <axis index="4" center="-1" range="2" />
-            <button index="4" ignore="true" />
-            <button index="5" ignore="true" />
+            <appearance id="game.controller.gamecube"/>
+            <axis index="3" center="-1" range="2"/>
+            <axis index="4" center="-1" range="2"/>
+            <button index="4" ignore="true"/>
+            <button index="5" ignore="true"/>
         </configuration>
         <controller id="game.controller.gamecube">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
             <feature name="controlstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
             <feature name="cstick">
-                <up axis="-2" />
-                <down axis="+2" />
-                <right axis="+5" />
-                <left axis="-5" />
+                <up axis="-2"/>
+                <down axis="+2"/>
+                <right axis="+5"/>
+                <left axis="-5"/>
             </feature>
-            <feature name="down" button="14" />
-            <feature name="l" axis="+3" />
-            <feature name="left" button="15" />
-            <feature name="r" axis="+4" />
-            <feature name="right" button="13" />
-            <feature name="start" button="9" />
-            <feature name="up" button="12" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
-            <feature name="z" button="7" />
+            <feature name="down" button="14"/>
+            <feature name="l" axis="+3"/>
+            <feature name="left" button="15"/>
+            <feature name="r" axis="+4"/>
+            <feature name="right" button="13"/>
+            <feature name="start" button="9"/>
+            <feature name="up" button="12"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/usb_gamepad____________10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/usb_gamepad____________10b_2a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="usb gamepad           " provider="linux" buttoncount="10" axiscount="2">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="6" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="6"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/linux/usb_gamepad_lowercase_10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/linux/usb_gamepad_lowercase_10b_2a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="usb gamepad" provider="linux" buttoncount="10" axiscount="2">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="left" axis="-0" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="6" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-1" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="left" axis="-0"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="6"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-1"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/sdl/SDL_Game_Controller_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/sdl/SDL_Game_Controller_15b_6a.xml
@@ -1,37 +1,37 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="SDL Game Controller" provider="sdl" buttoncount="15" axiscount="6">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="12" />
-            <feature name="guide" button="14" />
-            <feature name="left" button="13" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="12"/>
+            <feature name="guide" button="14"/>
+            <feature name="left" button="13"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="8" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="right" button="11" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="8"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="right" button="11"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-3" />
-                <down axis="+3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-3"/>
+                <down axis="+3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="9" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="10" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="9"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="10"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/8Bitdo_Zero_GamePad_v0A12_p0001_16b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/8Bitdo_Zero_GamePad_v0A12_p0001_16b_8a.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="8Bitdo Zero GamePad" provider="udev" vid="0A12" pid="0001" buttoncount="16" axiscount="8">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="down" axis="+1" />
-            <feature name="leftbumper" button="6" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="7" />
-            <feature name="select" button="10" />
-            <feature name="start" button="11" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="down" axis="+1"/>
+            <feature name="leftbumper" button="6"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="7"/>
+            <feature name="select" button="10"/>
+            <feature name="start" button="11"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/DualSense_Wireless_Controller_v054C_p0CE6_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/DualSense_Wireless_Controller_v054C_p0CE6_13b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="DualSense Wireless Controller" provider="udev" vid="054C" pid="0CE6" buttoncount="13" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="10" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="11" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="10"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l3" button="11"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="12" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="12"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" axis="-7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="3"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="2"/>
+            <feature name="up" axis="-7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Generic___USB__Joystick___v0079_p0006_12b_7a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Generic___USB__Joystick___v0079_p0006_12b_7a.xml
@@ -1,24 +1,24 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Generic   USB  Joystick  " provider="udev" vid="0079" pid="0006" buttoncount="12" axiscount="7">
         <configuration>
-            <appearance id="game.controller.n64" />
+            <appearance id="game.controller.n64"/>
         </configuration>
         <controller id="game.controller.n64">
-            <feature name="a" button="6" />
-            <feature name="b" button="8" />
-            <feature name="cdown" button="2" />
-            <feature name="cleft" button="3" />
-            <feature name="cright" button="1" />
-            <feature name="cup" button="0" />
-            <feature name="down" axis="+6" />
-            <feature name="left" axis="-5" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+5" />
-            <feature name="rightbumper" button="5" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-6" />
-            <feature name="z" button="7" />
+            <feature name="a" button="6"/>
+            <feature name="b" button="8"/>
+            <feature name="cdown" button="2"/>
+            <feature name="cleft" button="3"/>
+            <feature name="cright" button="1"/>
+            <feature name="cup" button="0"/>
+            <feature name="down" axis="+6"/>
+            <feature name="left" axis="-5"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+5"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-6"/>
+            <feature name="z" button="7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/HID_6666_0667_v6666_p0667_16b_4a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/HID_6666_0667_v6666_p0667_16b_4a.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="HID 6666:0667" provider="udev" vid="6666" pid="0667" buttoncount="16" axiscount="4">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/HuiJia__USB_GamePad_v0E8F_p3013_16b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/HuiJia__USB_GamePad_v0E8F_p3013_16b_6a.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="HuiJia  USB GamePad" provider="linux" buttoncount="16" axiscount="6">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Logitech_Gamepad_F310_v046D_pC21D_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Logitech_Gamepad_F310_v046D_pC21D_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Logitech Gamepad F310" provider="udev" vid="046D" pid="C21D" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_0_v28DE_p11FF_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_0_v28DE_p11FF_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad 0" provider="udev" vid="28DE" pid="11FF" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_1_v28DE_p11FF_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_1_v28DE_p11FF_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad 1" provider="udev" vid="28DE" pid="11FF" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_2_v28DE_p11FF_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_2_v28DE_p11FF_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad 2" provider="udev" vid="28DE" pid="11FF" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_3_v28DE_p11FF_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_360_pad_3_v28DE_p11FF_11b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box 360 pad 3" provider="udev" vid="28DE" pid="11FF" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_One_pad__Firmware_2015__v045E_p02DD_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_One_pad__Firmware_2015__v045E_p02DD_11b_8a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box One pad (Firmware 2015)" provider="udev" vid="045E" pid="02DD" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_One_pad_v045E_p02E6_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Microsoft_X-Box_One_pad_v045E_p02E6_11b_8a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Microsoft X-Box One pad" provider="udev" vid="045E" pid="02E6" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/ShanWan_PS_R__Ga_epad_v054C_p0268_17b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/ShanWan_PS_R__Ga_epad_v054C_p0268_17b_6a.xml
@@ -1,27 +1,27 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="ShanWan PS(R) Ga`epad" provider="udev" vid="054C" pid="0268" buttoncount="17" axiscount="6">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
+            <appearance id="game.controller.ps.dualanalog"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="10" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" button="14" />
-            <feature name="l3" button="11" />
-            <feature name="left" button="15" />
-            <feature name="leftbumper" button="4" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="r3" button="12" />
-            <feature name="right" button="16" />
-            <feature name="rightbumper" button="5" />
-            <feature name="righttrigger" button="7" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" button="13" />
+            <feature name="analog" button="10"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" button="14"/>
+            <feature name="l3" button="11"/>
+            <feature name="left" button="15"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="r3" button="12"/>
+            <feature name="right" button="16"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="3"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="2"/>
+            <feature name="up" button="13"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_DualSense_Wireless__v054C_p0CE6_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_DualSense_Wireless__v054C_p0CE6_13b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony Interactive Entertainment DualSense Wireless Controller" provider="udev" vid="054C" pid="0CE6" buttoncount="13" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="10" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="11" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="10"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l3" button="11"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="12" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="12"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" axis="-7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="3"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="2"/>
+            <feature name="up" axis="-7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_13b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_13b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony Interactive Entertainment Wireless Controller" provider="udev" vid="054C" pid="09CC" buttoncount="13" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.ps.dualanalog">
-            <feature name="analog" button="10" />
-            <feature name="circle" button="1" />
-            <feature name="cross" button="0" />
-            <feature name="down" axis="+7" />
-            <feature name="l3" button="11" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="analog" button="10"/>
+            <feature name="circle" button="1"/>
+            <feature name="cross" button="0"/>
+            <feature name="down" axis="+7"/>
+            <feature name="l3" button="11"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="r3" button="12" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="r3" button="12"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="righttrigger" axis="+5" />
-            <feature name="select" button="8" />
-            <feature name="square" button="3" />
-            <feature name="start" button="9" />
-            <feature name="triangle" button="2" />
-            <feature name="up" axis="-7" />
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="select" button="8"/>
+            <feature name="square" button="3"/>
+            <feature name="start" button="9"/>
+            <feature name="triangle" button="2"/>
+            <feature name="up" axis="-7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_14b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Sony_Interactive_Entertainment_Wireless_Controller_v054C_p09CC_14b_8a.xml
@@ -1,43 +1,43 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Sony Interactive Entertainment Wireless Controller" provider="udev" vid="054C" pid="09CC" buttoncount="14" axiscount="8">
         <configuration>
-            <appearance id="game.controller.ps.dualanalog" />
-            <axis index="3" center="-1" range="2" />
-            <axis index="4" center="-1" range="2" />
-            <button index="6" ignore="true" />
-            <button index="7" ignore="true" />
+            <appearance id="game.controller.ps.dualanalog"/>
+            <axis index="3" center="-1" range="2"/>
+            <axis index="4" center="-1" range="2"/>
+            <button index="6" ignore="true"/>
+            <button index="7" ignore="true"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="back" button="8" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="13" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="back" button="8"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="13"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="10" />
-            <feature name="lefttrigger" axis="+3" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="10"/>
+            <feature name="lefttrigger" axis="+3"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-5" />
-                <down axis="+5" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="-5"/>
+                <down axis="+5"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="11" />
-            <feature name="righttrigger" axis="+4" />
-            <feature name="start" button="9" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="11"/>
+            <feature name="righttrigger" axis="+4"/>
+            <feature name="start" button="9"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_360_Wireless_Receiver__XBOX__v045E_p0291_15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_360_Wireless_Receiver__XBOX__v045E_p0291_15b_8a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver (XBOX)" provider="udev" vid="045E" pid="0291" buttoncount="15" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="14" />
-            <feature name="guide" button="8" />
-            <feature name="left" button="11" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="14"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" button="11"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="12" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="12"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="13" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="13"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_360_Wireless_Receiver__XBOX__v045E_p02A1_15b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_360_Wireless_Receiver__XBOX__v045E_p02A1_15b_8a.xml
@@ -1,41 +1,41 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360 Wireless Receiver (XBOX)" provider="udev" vid="045E" pid="02A1" buttoncount="15" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
-            <axis index="2" center="-1" range="2" />
-            <axis index="5" center="-1" range="2" />
+            <appearance id="game.controller.default"/>
+            <axis index="2" center="-1" range="2"/>
+            <axis index="5" center="-1" range="2"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="14" />
-            <feature name="guide" button="8" />
-            <feature name="left" button="11" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="14"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" button="11"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" button="12" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" button="12"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="13" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="13"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_One_Wireless_Controller_11b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/Xbox_One_Wireless_Controller_11b_8a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox One Wireless Controller" provider="udev" buttoncount="11" axiscount="8">
         <configuration>
-            <appearance id="game.controller.default" />
+            <appearance id="game.controller.default"/>
         </configuration>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" axis="+7" />
-            <feature name="guide" button="8" />
-            <feature name="left" axis="-6" />
-            <feature name="leftbumper" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" axis="+7"/>
+            <feature name="guide" button="8"/>
+            <feature name="left" axis="-6"/>
+            <feature name="leftbumper" button="4"/>
             <feature name="leftstick">
-                <up axis="-1" />
-                <down axis="+1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="-1"/>
+                <down axis="+1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="9" />
-            <feature name="lefttrigger" axis="+2" />
-            <feature name="right" axis="+6" />
-            <feature name="rightbumper" button="5" />
+            <feature name="leftthumb" button="9"/>
+            <feature name="lefttrigger" axis="+2"/>
+            <feature name="right" axis="+6"/>
+            <feature name="rightbumper" button="5"/>
             <feature name="rightstick">
-                <up axis="-4" />
-                <down axis="+4" />
-                <right axis="+3" />
-                <left axis="-3" />
+                <up axis="-4"/>
+                <down axis="+4"/>
+                <right axis="+3"/>
+                <left axis="-3"/>
             </feature>
-            <feature name="rightthumb" button="10" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" axis="-7" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="10"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" axis="-7"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/mayflash_limited_MAYFLASH_GameCube_Controller_Adap_v0079_p1844_16b_8a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/mayflash_limited_MAYFLASH_GameCube_Controller_Adap_v0079_p1844_16b_8a.xml
@@ -1,22 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="mayflash limited MAYFLASH GameCube Controller Adapter" provider="udev" vid="0079" pid="1844" buttoncount="16" axiscount="8">
         <configuration>
-            <appearance id="game.controller.gamecube" />
+            <appearance id="game.controller.gamecube"/>
         </configuration>
         <controller id="game.controller.gamecube">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" button="14" />
-            <feature name="l" axis="+3" />
-            <feature name="left" button="15" />
-            <feature name="r" axis="+4" />
-            <feature name="right" button="13" />
-            <feature name="start" button="9" />
-            <feature name="up" button="12" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
-            <feature name="z" button="7" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" button="14"/>
+            <feature name="l" axis="+3"/>
+            <feature name="left" button="15"/>
+            <feature name="r" axis="+4"/>
+            <feature name="right" button="13"/>
+            <feature name="start" button="9"/>
+            <feature name="up" button="12"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
+            <feature name="z" button="7"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/udev/usb_gamepad____________v0810_pE501_10b_2a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/udev/usb_gamepad____________v0810_pE501_10b_2a.xml
@@ -1,20 +1,20 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="usb gamepad           " provider="udev" vid="0810" pid="E501" buttoncount="10" axiscount="2">
         <configuration>
-            <appearance id="game.controller.snes" />
+            <appearance id="game.controller.snes"/>
         </configuration>
         <controller id="game.controller.snes">
-            <feature name="a" button="1" />
-            <feature name="b" button="2" />
-            <feature name="down" axis="+1" />
-            <feature name="leftbumper" button="4" />
-            <feature name="right" axis="+0" />
-            <feature name="rightbumper" button="6" />
-            <feature name="select" button="8" />
-            <feature name="start" button="9" />
-            <feature name="x" button="0" />
-            <feature name="y" button="3" />
+            <feature name="a" button="1"/>
+            <feature name="b" button="2"/>
+            <feature name="down" axis="+1"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="right" axis="+0"/>
+            <feature name="rightbumper" button="6"/>
+            <feature name="select" button="8"/>
+            <feature name="start" button="9"/>
+            <feature name="x" button="0"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/xarcade/X-Arcade_Tankstick_Player_1_vAA55_p0101_14b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/xarcade/X-Arcade_Tankstick_Player_1_vAA55_p0101_14b.xml
@@ -1,21 +1,21 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="X-Arcade Tankstick (Player 1)" provider="xarcade" vid="AA55" pid="0101" buttoncount="14">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="9" />
-            <feature name="down" button="13" />
-            <feature name="left" button="10" />
-            <feature name="leftbumper" button="5" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" button="11" />
-            <feature name="rightbumper" button="2" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="8" />
-            <feature name="up" button="12" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="9"/>
+            <feature name="down" button="13"/>
+            <feature name="left" button="10"/>
+            <feature name="leftbumper" button="5"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" button="11"/>
+            <feature name="rightbumper" button="2"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="12"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/xarcade/X-Arcade_Tankstick_Player_2_vAA55_p0101_14b.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/xarcade/X-Arcade_Tankstick_Player_2_vAA55_p0101_14b.xml
@@ -1,21 +1,21 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="X-Arcade Tankstick (Player 2)" provider="xarcade" vid="AA55" pid="0101" buttoncount="14">
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="9" />
-            <feature name="down" button="13" />
-            <feature name="left" button="10" />
-            <feature name="leftbumper" button="5" />
-            <feature name="lefttrigger" button="6" />
-            <feature name="right" button="11" />
-            <feature name="rightbumper" button="2" />
-            <feature name="righttrigger" button="7" />
-            <feature name="start" button="8" />
-            <feature name="up" button="12" />
-            <feature name="x" button="3" />
-            <feature name="y" button="4" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="9"/>
+            <feature name="down" button="13"/>
+            <feature name="left" button="10"/>
+            <feature name="leftbumper" button="5"/>
+            <feature name="lefttrigger" button="6"/>
+            <feature name="right" button="11"/>
+            <feature name="rightbumper" button="2"/>
+            <feature name="righttrigger" button="7"/>
+            <feature name="start" button="8"/>
+            <feature name="up" button="12"/>
+            <feature name="x" button="3"/>
+            <feature name="y" button="4"/>
         </controller>
     </device>
 </buttonmap>

--- a/peripheral.joystick/resources/buttonmaps/xml/xinput/Xbox_360-compatible_controller_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/xinput/Xbox_360-compatible_controller_15b_6a.xml
@@ -1,39 +1,39 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <buttonmap>
     <device name="Xbox 360-compatible controller" provider="xinput" buttoncount="15" axiscount="6">
-        <configuration />
+        <configuration/>
         <controller id="game.controller.default">
-            <feature name="a" button="0" />
-            <feature name="b" button="1" />
-            <feature name="back" button="6" />
-            <feature name="down" button="12" />
-            <feature name="guide" button="14" />
-            <feature name="left" button="13" />
-            <feature name="leftbumper" button="4" />
-            <feature name="leftmotor" motor="0" />
+            <feature name="a" button="0"/>
+            <feature name="b" button="1"/>
+            <feature name="back" button="6"/>
+            <feature name="down" button="12"/>
+            <feature name="guide" button="14"/>
+            <feature name="left" button="13"/>
+            <feature name="leftbumper" button="4"/>
+            <feature name="leftmotor" motor="0"/>
             <feature name="leftstick">
-                <up axis="+1" />
-                <down axis="-1" />
-                <right axis="+0" />
-                <left axis="-0" />
+                <up axis="+1"/>
+                <down axis="-1"/>
+                <right axis="+0"/>
+                <left axis="-0"/>
             </feature>
-            <feature name="leftthumb" button="8" />
-            <feature name="lefttrigger" axis="+4" />
-            <feature name="right" button="11" />
-            <feature name="rightbumper" button="5" />
-            <feature name="rightmotor" motor="1" />
+            <feature name="leftthumb" button="8"/>
+            <feature name="lefttrigger" axis="+4"/>
+            <feature name="right" button="11"/>
+            <feature name="rightbumper" button="5"/>
+            <feature name="rightmotor" motor="1"/>
             <feature name="rightstick">
-                <up axis="+3" />
-                <down axis="-3" />
-                <right axis="+2" />
-                <left axis="-2" />
+                <up axis="+3"/>
+                <down axis="-3"/>
+                <right axis="+2"/>
+                <left axis="-2"/>
             </feature>
-            <feature name="rightthumb" button="9" />
-            <feature name="righttrigger" axis="+5" />
-            <feature name="start" button="7" />
-            <feature name="up" button="10" />
-            <feature name="x" button="2" />
-            <feature name="y" button="3" />
+            <feature name="rightthumb" button="9"/>
+            <feature name="righttrigger" axis="+5"/>
+            <feature name="start" button="7"/>
+            <feature name="up" button="10"/>
+            <feature name="x" button="2"/>
+            <feature name="y" button="3"/>
         </controller>
     </device>
 </buttonmap>


### PR DESCRIPTION
Tinyxml2 saves xml different:

* Includes  `encoding="UTF-8"`
* Removes spaces before `/>`

To reduce git conflicts when copying over existing buttonmaps, update them for timyxml2.