### PR TITLE
Add "Select" button mapping for Amiga CD32 controller

### DIFF
--- a/peripheral.joystick/resources/buttonmaps/xml/xinput/Xbox_360-compatible_controller_15b_6a.xml
+++ b/peripheral.joystick/resources/buttonmaps/xml/xinput/Xbox_360-compatible_controller_15b_6a.xml
@@ -12,6 +12,7 @@
             <feature name="red" button="0"/>
             <feature name="rewind" button="4"/>
             <feature name="right" button="11"/>
+            <feature name="select" button="6"/>
             <feature name="up" button="10"/>
             <feature name="yellow" button="3"/>
         </controller>


### PR DESCRIPTION
## Description

Part of "Amiga Input Refinement" epic. 

This adds the additional \"Select\" button on the Amiga CD32 controller to the default map for XInput controllers on Windows. The button mapper applies it to every other platform.

## Motivation and context

Requested here: https://github.com/kodi-game/game.libretro.uae/issues/11

## Related PRs

Amiga Input Tuning:

* https://github.com/kodi-game/controller-topology-project/pull/442
* https://github.com/kodi-game/game.libretro.uae/pull/12
* https://github.com/kodi-game/game.libretro.uae2021/pull/1
* https://github.com/xbmc/peripheral.joystick/pull/340