### PR TITLE
Correct a reversed expiration check on directory caching.

### DIFF
--- a/src/filesystem/DirectoryCache.cpp
+++ b/src/filesystem/DirectoryCache.cpp
@@ -53,7 +53,7 @@ bool CDirectoryCache::GetDirectory(const std::string& path, std::vector<kodi::vf
     const std::chrono::steady_clock::time_point timestamp = record.first;
     const std::chrono::steady_clock::time_point expires = timestamp + DIRECTORY_LIFETIME;
 
-    if (expires <= std::chrono::steady_clock::now())
+    if (std::chrono::steady_clock::now() < expires)
     {
       items = record.second;
       return true;


### PR DESCRIPTION
When looking into a memory leak with peripherals [PR](https://github.com/xbmc/xbmc/pull/28438), claude randomly pointed out that this check was incorrect, and actually the reverse of what is desired. So I did some digging.

From my understanding, `m_cache` hold the list of files for a directory, and a timestamp for when that list should be considered stale. If the path is stale, it should return false without assigning a value to items, which will cause a fresh pull of the directory contents, which is placed back into the cache. If not stale, it returns the cache contents and true, so no disk reads are necessary.

I applied some logs to the function and found that indeed the existing code does appear to do the exact opposite of what is wanted here. Instead of returning false on the first call with a stale cache, it would return true, and then proceed to return false to every proceeding call. This would result in stale data being returned the first call, then no cache return for the rest.
