### PR TITLE
Prefer udev over the joystick API so rumble works

### DIFF
--- a/src/api/JoystickManager.cpp
+++ b/src/api/JoystickManager.cpp
@@ -122,11 +122,15 @@ const std::vector<EJoystickInterface>& CJoystickManager::GetSupportedInterfaces(
 #if defined(HAVE_SDL_GAMEPAD)
     supportedInterfaces.push_back(EJoystickInterface::SDL);
 #endif
-#if defined(HAVE_LINUX_JOYSTICK)
-    supportedInterfaces.push_back(EJoystickInterface::LINUX);
-#endif
+    // udev before the joystick API. Both enumerate the same pads, but only udev
+    // drives force feedback -- CJoystickLinux has no SetMotorState at all -- so
+    // taking the joystick API first leaves rumble unavailable, silently, on any
+    // Linux system that has both. That is most of them.
 #if defined(HAVE_UDEV)
     supportedInterfaces.push_back(EJoystickInterface::UDEV);
+#endif
+#if defined(HAVE_LINUX_JOYSTICK)
+    supportedInterfaces.push_back(EJoystickInterface::LINUX);
 #endif
 
   // OSX


### PR DESCRIPTION
Rumble does not work on Linux for any controller, with any emulator, and I think this is why.

`GetSupportedInterfaces()` is documented as returning interfaces "in order of priority", and lists the joystick API before udev:

```cpp
#if defined(HAVE_LINUX_JOYSTICK)
    supportedInterfaces.push_back(EJoystickInterface::LINUX);
#endif
#if defined(HAVE_UDEV)
    supportedInterfaces.push_back(EJoystickInterface::UDEV);
#endif
```

Both enumerate the same pads, but only udev drives force feedback. `CJoystickUdev` has `SetMotorState` with strong and weak motors and the `ff_effect` upload to go with it; `CJoystickLinux` has neither — there is no motor handling in that backend at all.

So on any Linux system built with both — which is most, and includes LibreELEC — the joystick API wins, udev is never reached, and rumble is unavailable. Silently: nothing logs a reason, because from the frontend's side the request is well-formed and simply goes nowhere.

This moves udev above it. The joystick API stays as the fallback wherever udev is unavailable.

### How it was found

Chasing rumble not working in RetroPlayer with an 8BitDo Pro 2 on LibreELEC. The chain checked out end to end — the core requests the rumble interface, the game add-on maps the motor, Kodi routes it to the right port — and then the peripheral declines it. The log line is `Enabling joystick interface "linux"`, and that backend has nothing to decline it *with*.

### Testing

Reasoned from the source rather than measured: I have not yet rebuilt the add-on with this change and confirmed a controller buzzes. Flagging that plainly. I can test it on LibreELEC hardware and follow up here — happy to hold the PR until I have, if you would rather see that first.

One thing I could not answer from the source alone is whether the ordering was deliberate. If udev was put second for a reason I have missed, this is the wrong fix and I would rather know than have it merged.