### PR TITLE
Default the Linux driver to udev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,7 +225,7 @@ endif()
 
 set(LINUX_SELECT_LINE "\
         <setting id=\"driver_linux\" type=\"integer\" label=\"30001\">
-          <default>0</default>
+          <default>1</default>
           <constraints>
             <options>
               <option label=\"30005\">0</option>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,11 +225,11 @@ endif()
 
 set(LINUX_SELECT_LINE "\
         <setting id=\"driver_linux\" type=\"integer\" label=\"30001\">
-          <default>1</default>
+          <default>0</default>
           <constraints>
             <options>
-              <option label=\"30005\">0</option>
-              <option label=\"30007\">1</option>
+              <option label=\"30007\">0</option>
+              <option label=\"30005\">1</option>
               <option label=\"30002\">2</option>
             </options>
           </constraints>

--- a/src/api/udev/JoystickUdev.cpp
+++ b/src/api/udev/JoystickUdev.cpp
@@ -160,7 +160,19 @@ void CJoystickUdev::Play(bool bPlayStop)
     esyslog("[udev]: Failed to play rumble effect %d on \"%s\" - %s", m_effect, Name().c_str(), strerror(errno));
 
   if (!bPlayStop)
+  {
+    // Give the slot back. Dropping the id without this leaks an effect on the
+    // device every time a rumble stops, and a device holds only a handful --
+    // an 8BitDo Pro 2 runs out after a few, and every upload from then on
+    // fails with ENOSPC, so rumble stops working for the rest of the session.
+    if (m_effect != -1 && ioctl(m_fd, EVIOCRMFF, m_effect) < 0)
+    {
+      esyslog("[udev]: Failed to remove rumble effect %d on \"%s\" - %s", m_effect,
+              Name().c_str(), strerror(errno));
+    }
+
     m_effect = -1;
+  }
 }
 
 void CJoystickUdev::UpdateMotorState(const std::array<uint16_t, MOTOR_COUNT>& motors)

--- a/src/settings/Settings.cpp
+++ b/src/settings/Settings.cpp
@@ -60,9 +60,11 @@ void CSettings::SetSetting(const std::string& strName, const kodi::CSettingValue
 
     if (strName == SETTING_LINUX_DRIVER)
     {
+      // udev first, so the default index selects the only one of the two that
+      // drives force feedback
       drivers = {
-          EJoystickInterface::LINUX,
           EJoystickInterface::UDEV,
+          EJoystickInterface::LINUX,
           EJoystickInterface::NONE,
       };
     }


### PR DESCRIPTION
Follow-up to #346, which I got wrong — thanks for the steer there.

I'd assumed the order in `GetSupportedInterfaces()` selected the backend. It doesn't: `Initialize()` creates every supported interface and enables none, and the choice is the `driver_linux` setting, an index into `{LINUX, UDEV, NONE}` in `Settings.cpp`. Confirmed on hardware — with #346 built and installed the log still said `Enabling joystick interface "linux"`, and only changing the setting moved it.

So this changes the default instead, which is the one line that actually decides it.

### Why

Both backends enumerate the same pads, but only udev drives force feedback. `CJoystickUdev` has `SetMotorState` and the `ff_effect` upload; `CJoystickLinux` has no motor handling at all. So on a fresh install rumble is unavailable for every controller and every emulator, and nothing indicates why — the request is well-formed the whole way down and simply stops at a backend with nothing to receive it.

udev is also better informed: it reports the device's motor count, and its capability queries cover things the joystick API can't express.

The setting stays, so anyone who wants the old behaviour can select it, and existing installations keep whatever they already have — only the default for new ones changes.

### Testing

Changing this setting by hand on LibreELEC switched the log to `Enabling joystick interface "udev"` and the pad continued to work normally for ordinary input.

Rumble itself needs a second fix on the Kodi side — nothing ever maps a motor to a driver primitive, because the configuration wizard can't ask a user to activate one (garbear/xbmc#154). I'm testing the two together and will confirm here once I've felt a controller actually buzz, rather than claim it beforehand.

You mentioned wanting this before B2 — happy to adjust the approach if you'd rather it were handled another way.