### PR TITLE
Drop p8-platform for the standard library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,11 @@ include(CheckIncludeFiles)
 # --- Add-on Dependencies ------------------------------------------------------
 
 find_package(Kodi REQUIRED)
-find_package(p8-platform REQUIRED)
 find_package(TinyXML REQUIRED)
 
 include_directories(${INCLUDES}
                     ${PROJECT_SOURCE_DIR}/src
                     ${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways (becomes done in future)
-                    ${p8-platform_INCLUDE_DIRS}
                     ${TINYXML_INCLUDE_DIRS})
 
 set(JOYSTICK_SOURCES src/addon.cpp
@@ -111,7 +109,8 @@ set(JOYSTICK_HEADERS src/addon.h
                      src/storage/xml/JoystickFamilyDefinitions.h
                      src/utils/CommonIncludes.h
                      src/utils/CommonMacros.h
-                     src/utils/StringUtils.h)
+                     src/utils/StringUtils.h
+                     src/utils/Timer.h)
 
 if(CORE_SYSTEM_NAME MATCHES windows)
   list(APPEND JOYSTICK_SOURCES src/utils/windows/CharsetConverter.cpp)
@@ -125,7 +124,7 @@ if(HAVE_SYSLOG)
   list(APPEND JOYSTICK_HEADERS src/log/LogSyslog.h)
 endif()
 
-list(APPEND DEPLIBS ${p8-platform_LIBRARIES} ${TINYXML_LIBRARIES})
+list(APPEND DEPLIBS ${TINYXML_LIBRARIES})
 
 # --- SDL2 ---------------------------------------------------------------------
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-peripheral-joystick
 Priority: extra
 Maintainer: wsnipex <wsnipex@a1.net>
 Build-Depends: debhelper (>= 9.0.0), cmake (>= 3.1), libtinyxml-dev,
-               kodi-addon-dev, pkg-config, libp8-platform-dev, libudev-dev
+               kodi-addon-dev, pkg-config, libudev-dev
 Standards-Version: 3.9.6
 Section: libs
 

--- a/src/api/Joystick.cpp
+++ b/src/api/Joystick.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "Joystick.h"
+#include "utils/Timer.h"
 #include "JoystickManager.h"
 #include "JoystickTranslator.h"
 #include "JoystickUtils.h"
@@ -27,14 +28,13 @@
 #include "utils/CommonMacros.h"
 #include "utils/StringUtils.h"
 
-#include "p8-platform/util/timeutils.h"
 
 using namespace JOYSTICK;
 
 #define ANALOG_EPSILON  0.0001f
 
 CJoystick::CJoystick(EJoystickInterface interfaceType)
- : m_discoverTimeMs(P8PLATFORM::GetTimeMs()),
+ : m_discoverTimeMs(GetTimeMs()),
    m_activateTimeMs(-1),
    m_firstEventTimeMs(-1),
    m_lastEventTimeMs(-1)
@@ -134,7 +134,7 @@ void CJoystick::Activate()
 {
   if (!IsActive())
   {
-    m_activateTimeMs = P8PLATFORM::GetTimeMs();
+    m_activateTimeMs = GetTimeMs();
 
     if (CJoystickUtils::IsGhostJoystick(*this))
     {
@@ -223,8 +223,8 @@ void CJoystick::SetAxisValue(unsigned int axisIndex, long value, long maxAxisAmo
 void CJoystick::UpdateTimers(void)
 {
   if (m_firstEventTimeMs < 0)
-    m_firstEventTimeMs = P8PLATFORM::GetTimeMs();
-  m_lastEventTimeMs = P8PLATFORM::GetTimeMs();
+    m_firstEventTimeMs = GetTimeMs();
+  m_lastEventTimeMs = GetTimeMs();
 }
 
 float CJoystick::NormalizeAxis(long value, long maxAxisAmount)

--- a/src/api/JoystickManager.cpp
+++ b/src/api/JoystickManager.cpp
@@ -47,11 +47,11 @@
 #include "settings/Settings.h"
 #include "utils/CommonMacros.h"
 
+#include <mutex>
 #include <algorithm>
 #include <iterator>
 
 using namespace JOYSTICK;
-using namespace P8PLATFORM;
 
 // --- Utility functions -------------------------------------------------------
 
@@ -169,7 +169,7 @@ IJoystickInterface* CJoystickManager::CreateInterface(EJoystickInterface iface)
 
 bool CJoystickManager::Initialize(IScannerCallback* scanner)
 {
-  CLockObject lock(m_interfacesMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
 
   m_scanner = scanner;
 
@@ -191,12 +191,12 @@ bool CJoystickManager::Initialize(IScannerCallback* scanner)
 void CJoystickManager::Deinitialize(void)
 {
   {
-    CLockObject lock(m_joystickMutex);
+    std::lock_guard<std::recursive_mutex> lock(m_joystickMutex);
     m_joysticks.clear();
   }
 
   {
-    CLockObject lock(m_interfacesMutex);
+    std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
     for (auto pInterface : m_interfaces)
       SetEnabled(pInterface->Type(), false);
     safe_delete_vector(m_interfaces);
@@ -207,7 +207,7 @@ void CJoystickManager::Deinitialize(void)
 
 bool CJoystickManager::SupportsRumble(void) const
 {
-  CLockObject lock(m_interfacesMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
   for (auto pInterface : m_enabledInterfaces)
   {
     if (pInterface->SupportsRumble())
@@ -219,7 +219,7 @@ bool CJoystickManager::SupportsRumble(void) const
 
 bool CJoystickManager::SupportsPowerOff(void) const
 {
-  CLockObject lock(m_interfacesMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
   for (auto pInterface : m_enabledInterfaces)
   {
     if (pInterface->SupportsPowerOff())
@@ -231,7 +231,7 @@ bool CJoystickManager::SupportsPowerOff(void) const
 
 bool CJoystickManager::HasInterface(EJoystickInterface iface) const
 {
-  CLockObject lock(m_interfacesMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
   for (auto pInterface : m_interfaces)
   {
     if (pInterface->Type() == iface)
@@ -243,7 +243,7 @@ bool CJoystickManager::HasInterface(EJoystickInterface iface) const
 
 void CJoystickManager::SetEnabled(EJoystickInterface iface, bool bEnabled)
 {
-  CLockObject lock(m_interfacesMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
 
   for (auto pInterface : m_interfaces)
   {
@@ -274,7 +274,7 @@ void CJoystickManager::SetEnabled(EJoystickInterface iface, bool bEnabled)
 
 bool CJoystickManager::IsEnabled(IJoystickInterface* iface)
 {
-  CLockObject lock(m_interfacesMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
   return m_enabledInterfaces.find(iface) != m_enabledInterfaces.end();
 }
 
@@ -282,13 +282,13 @@ bool CJoystickManager::PerformJoystickScan(JoystickVector& joysticks)
 {
   JoystickVector scanResults;
   {
-    CLockObject lock(m_interfacesMutex);
+    std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
     // Scan for joysticks (this can take a while, don't block)
     for (auto pInterface : m_enabledInterfaces)
       pInterface->ScanForJoysticks(scanResults);
   }
 
-  CLockObject lock(m_joystickMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_joystickMutex);
 
   // Unregister removed joysticks
   for (int i = (int)m_joysticks.size() - 1; i >= 0; i--)
@@ -330,7 +330,7 @@ bool CJoystickManager::PerformJoystickScan(JoystickVector& joysticks)
 
 JoystickPtr CJoystickManager::GetJoystick(unsigned int index) const
 {
-  CLockObject lock(m_joystickMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_joystickMutex);
 
   for (JoystickVector::const_iterator it = m_joysticks.begin(); it != m_joysticks.end(); ++it)
   {
@@ -345,7 +345,7 @@ JoystickVector CJoystickManager::GetJoysticks(const kodi::addon::Joystick& joyst
 {
   JoystickVector result;
 
-  CLockObject lock(m_joystickMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_joystickMutex);
 
   for (const auto& joystick : m_joysticks)
   {
@@ -361,7 +361,7 @@ JoystickVector CJoystickManager::GetJoysticks(const kodi::addon::Joystick& joyst
 
 bool CJoystickManager::GetEvents(std::vector<kodi::addon::PeripheralEvent>& events)
 {
-  CLockObject lock(m_joystickMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_joystickMutex);
 
   for (JoystickVector::iterator it = m_joysticks.begin(); it != m_joysticks.end(); ++it)
     (*it)->GetEvents(events);
@@ -373,7 +373,7 @@ bool CJoystickManager::SendEvent(const kodi::addon::PeripheralEvent& event)
 {
   bool bHandled = false;
 
-  CLockObject lock(m_joystickMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_joystickMutex);
 
   for (const JoystickPtr& joystick : m_joysticks)
   {
@@ -390,7 +390,7 @@ bool CJoystickManager::SendEvent(const kodi::addon::PeripheralEvent& event)
 
 void CJoystickManager::ProcessEvents()
 {
-  CLockObject lock(m_joystickMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_joystickMutex);
 
   for (const JoystickPtr& joystick : m_joysticks)
     joystick->ProcessEvents();
@@ -398,7 +398,7 @@ void CJoystickManager::ProcessEvents()
 
 void CJoystickManager::SetChanged(bool bChanged)
 {
-  CLockObject lock(m_changedMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_changedMutex);
   m_bChanged = bChanged;
 }
 
@@ -406,7 +406,7 @@ void CJoystickManager::TriggerScan(void)
 {
   bool bChanged;
   {
-    CLockObject lock(m_changedMutex);
+    std::lock_guard<std::recursive_mutex> lock(m_changedMutex);
     bChanged = m_bChanged;
     m_bChanged = false;
   }
@@ -419,7 +419,7 @@ const ButtonMap& CJoystickManager::GetButtonMap(const std::string& provider)
 {
   static ButtonMap empty;
 
-  CLockObject lock(m_interfacesMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_interfacesMutex);
 
   for (auto pInterface : m_interfaces)
   {

--- a/src/api/JoystickManager.h
+++ b/src/api/JoystickManager.h
@@ -22,8 +22,8 @@
 #include "JoystickTypes.h"
 #include "buttonmapper/ButtonMapTypes.h"
 
+#include <mutex>
 #include <kodi/addon-instance/PeripheralUtils.h>
-#include "p8-platform/threads/mutex.h"
 
 #include <set>
 #include <vector>
@@ -162,8 +162,8 @@ namespace JOYSTICK
     JoystickVector                   m_joysticks;
     unsigned int                     m_nextJoystickIndex;
     bool                             m_bChanged;
-    mutable P8PLATFORM::CMutex       m_changedMutex;
-    mutable P8PLATFORM::CMutex         m_interfacesMutex;
-    mutable P8PLATFORM::CMutex         m_joystickMutex;
+    mutable std::recursive_mutex       m_changedMutex;
+    mutable std::recursive_mutex         m_interfacesMutex;
+    mutable std::recursive_mutex         m_joystickMutex;
   };
 }

--- a/src/api/cocoa/JoystickCocoa.cpp
+++ b/src/api/cocoa/JoystickCocoa.cpp
@@ -22,10 +22,10 @@
 #include "api/JoystickTypes.h"
 #include "utils/CommonMacros.h"
 
+#include <mutex>
 #include <assert.h>
 
 using namespace JOYSTICK;
-using namespace P8PLATFORM;
 
 #define MAX_JOYSTICK_BUTTONS  512
 
@@ -57,7 +57,7 @@ bool CJoystickCocoa::Equals(const CJoystick* rhs) const
 
 bool CJoystickCocoa::Initialize(void)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   if (!m_bInitialized)
   {
@@ -133,7 +133,7 @@ bool CJoystickCocoa::Initialize(void)
 
 void CJoystickCocoa::Deinitialize(void)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   CJoystick::Deinitialize();
 
@@ -145,31 +145,31 @@ void CJoystickCocoa::Deinitialize(void)
 
 bool CJoystickCocoa::GetEvents(std::vector<kodi::addon::PeripheralEvent>& events)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   return CJoystick::GetEvents(events);
 }
 
 bool CJoystickCocoa::ScanEvents(void)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   return m_bInitialized; // Events arrive asynchronously
 }
 
 void CJoystickCocoa::SetButtonValue(unsigned int buttonIndex, JOYSTICK_STATE_BUTTON buttonValue)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   CJoystick::SetButtonValue(buttonIndex, buttonValue);
 }
 
 void CJoystickCocoa::SetHatValue(unsigned int hatIndex, JOYSTICK_STATE_HAT hatValue)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   CJoystick::SetHatValue(hatIndex, hatValue);
 }
 
 void CJoystickCocoa::SetAxisValue(unsigned int axisIndex, JOYSTICK_STATE_AXIS axisValue)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   CJoystick::SetAxisValue(axisIndex, axisValue);
 }
 

--- a/src/api/cocoa/JoystickCocoa.h
+++ b/src/api/cocoa/JoystickCocoa.h
@@ -22,12 +22,12 @@
 #include "JoystickInterfaceCocoa.h"
 #include "api/Joystick.h"
 
+#include <mutex>
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/hid/IOHIDBase.h>
 #include <IOKit/hid/IOHIDKeys.h>
 #include <IOKit/hid/IOHIDManager.h>
 
-#include "p8-platform/threads/mutex.h"
 
 namespace JOYSTICK
 {
@@ -69,6 +69,6 @@ namespace JOYSTICK
     CJoystickInterfaceCocoa* const m_api;
     std::vector<IOHIDElementRef> m_buttons;
     std::vector<CocoaAxis>       m_axes;
-    P8PLATFORM::CMutex m_mutex;
+    std::recursive_mutex m_mutex;
   };
 }

--- a/src/api/cocoa/JoystickInterfaceCocoa.cpp
+++ b/src/api/cocoa/JoystickInterfaceCocoa.cpp
@@ -23,10 +23,10 @@
 #include "api/JoystickManager.h"
 #include "api/JoystickTypes.h"
 
+#include <mutex>
 #include <algorithm>
 
 using namespace JOYSTICK;
-using namespace P8PLATFORM;
 
 // --- MatchingDictionary ------------------------------------------------------
 
@@ -140,7 +140,7 @@ void CJoystickInterfaceCocoa::Deinitialize(void)
 
 bool CJoystickInterfaceCocoa::ScanForJoysticks(JoystickVector& joysticks)
 {
-  CLockObject lock(m_deviceDiscoveryMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_deviceDiscoveryMutex);
 
   for (auto it = m_discoveredDevices.begin(); it != m_discoveredDevices.end(); ++it)
     joysticks.push_back(JoystickPtr(new CJoystickCocoa(*it, this)));
@@ -153,7 +153,7 @@ void CJoystickInterfaceCocoa::DeviceAdded(IOHIDDeviceRef device)
   bool bDeviceAdded = false;
 
   {
-    CLockObject lock(m_deviceDiscoveryMutex);
+    std::lock_guard<std::recursive_mutex> lock(m_deviceDiscoveryMutex);
 
     if (std::find(m_discoveredDevices.begin(), m_discoveredDevices.end(), device) == m_discoveredDevices.end())
     {
@@ -172,7 +172,7 @@ void CJoystickInterfaceCocoa::DeviceAdded(IOHIDDeviceRef device)
 void CJoystickInterfaceCocoa::DeviceRemoved(IOHIDDeviceRef device)
 {
   {
-    CLockObject lock(m_deviceDiscoveryMutex);
+    std::lock_guard<std::recursive_mutex> lock(m_deviceDiscoveryMutex);
     m_discoveredDevices.erase(std::remove(m_discoveredDevices.begin(), m_discoveredDevices.end(), device), m_discoveredDevices.end());
   }
 
@@ -185,7 +185,7 @@ void CJoystickInterfaceCocoa::InputValueChanged(IOHIDValueRef newValue)
   IOHIDElementRef element = IOHIDValueGetElement(newValue);
   IOHIDDeviceRef device = IOHIDElementGetDevice(element);
 
-  CLockObject lock(m_deviceInputMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_deviceInputMutex);
 
   for (std::vector<DeviceHandle>::iterator it = m_registeredDevices.begin(); it != m_registeredDevices.end(); ++it)
   {
@@ -196,14 +196,14 @@ void CJoystickInterfaceCocoa::InputValueChanged(IOHIDValueRef newValue)
 
 void CJoystickInterfaceCocoa::RegisterInputCallback(ICocoaInputCallback* callback, IOHIDDeviceRef device)
 {
-  CLockObject lock(m_deviceInputMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_deviceInputMutex);
 
   m_registeredDevices.push_back(std::make_pair(device, callback));
 }
 
 void CJoystickInterfaceCocoa::UnregisterInputCallback(ICocoaInputCallback* callback)
 {
-  CLockObject lock(m_deviceInputMutex);
+  std::lock_guard<std::recursive_mutex> lock(m_deviceInputMutex);
 
   for (std::vector<DeviceHandle>::iterator it = m_registeredDevices.begin(); it != m_registeredDevices.end(); )
   {

--- a/src/api/cocoa/JoystickInterfaceCocoa.h
+++ b/src/api/cocoa/JoystickInterfaceCocoa.h
@@ -21,8 +21,8 @@
 
 #include "api/IJoystickInterface.h"
 
-#include "p8-platform/threads/mutex.h"
 
+#include <mutex>
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/hid/IOHIDBase.h>
 #include <IOKit/hid/IOHIDKeys.h>
@@ -84,7 +84,7 @@ namespace JOYSTICK
     std::vector<IOHIDDeviceRef> m_discoveredDevices;
     std::vector<DeviceHandle>   m_registeredDevices;
 
-    P8PLATFORM::CMutex m_deviceDiscoveryMutex;
-    P8PLATFORM::CMutex m_deviceInputMutex;
+    std::recursive_mutex m_deviceDiscoveryMutex;
+    std::recursive_mutex m_deviceInputMutex;
   };
 }

--- a/src/api/udev/JoystickUdev.cpp
+++ b/src/api/udev/JoystickUdev.cpp
@@ -22,6 +22,7 @@
 #include "api/JoystickTypes.h"
 #include "log/Log.h"
 
+#include <mutex>
 #include <algorithm>
 #include <errno.h>
 #include <fcntl.h>
@@ -101,13 +102,12 @@ void CJoystickUdev::Deinitialize(void)
 
 void CJoystickUdev::ProcessEvents(void)
 {
-  using namespace P8PLATFORM;
 
   std::array<uint16_t, MOTOR_COUNT> motors;
   std::array<uint16_t, MOTOR_COUNT> previousMotors;
 
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     motors         = m_motors;
     previousMotors = m_previousMotors;
   }
@@ -143,7 +143,7 @@ void CJoystickUdev::ProcessEvents(void)
   }
 
   {
-    CLockObject lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     m_previousMotors = motors;
   }
 }
@@ -346,7 +346,6 @@ bool CJoystickUdev::GetProperties()
 
 bool CJoystickUdev::SetMotor(unsigned int motorIndex, float magnitude)
 {
-  using namespace P8PLATFORM;
 
   if (!m_bInitialized)
     return false;
@@ -359,7 +358,7 @@ bool CJoystickUdev::SetMotor(unsigned int motorIndex, float magnitude)
 
   uint16_t strength = std::min(0xffff, static_cast<int>(magnitude * 0xffff));
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   m_motors[motorIndex] = strength;
 

--- a/src/api/udev/JoystickUdev.h
+++ b/src/api/udev/JoystickUdev.h
@@ -41,8 +41,8 @@
 
 #include "api/Joystick.h"
 
-#include "p8-platform/threads/mutex.h"
 
+#include <mutex>
 #include <array>
 #include <linux/input.h>
 #include <map>
@@ -102,6 +102,6 @@ namespace JOYSTICK
     std::map<unsigned int, Axis>         m_axes_bind;   // Maps keycodes -> axis and axis info
     std::array<uint16_t, MOTOR_COUNT>    m_motors;
     std::array<uint16_t, MOTOR_COUNT>    m_previousMotors;
-    P8PLATFORM::CMutex                   m_mutex;
+    std::recursive_mutex                   m_mutex;
   };
 }

--- a/src/api/xinput/XInputDLL.cpp
+++ b/src/api/xinput/XInputDLL.cpp
@@ -19,10 +19,11 @@
  */
 
 #include "XInputDLL.h"
+
+#include <mutex>
 #include "log/Log.h"
 
 using namespace JOYSTICK;
-using namespace P8PLATFORM;
 
 CXInputDLL::CXInputDLL(void)
  : m_dll(NULL),
@@ -43,7 +44,7 @@ CXInputDLL& CXInputDLL::Get(void)
 
 bool CXInputDLL::Load(void)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   m_strVersion = "1.4";
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
@@ -107,7 +108,7 @@ bool CXInputDLL::Load(void)
 
 void CXInputDLL::Unload(void)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
 #if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY != WINAPI_FAMILY_APP)
   if (m_dll)
@@ -136,7 +137,7 @@ bool CXInputDLL::SupportsPowerOff(void) const
 
 bool CXInputDLL::GetState(unsigned int controllerId, XINPUT_STATE& state)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   if (!m_getState)
     return false;
@@ -154,7 +155,7 @@ bool CXInputDLL::GetState(unsigned int controllerId, XINPUT_STATE& state)
 
 bool CXInputDLL::GetStateWithGuide(unsigned int controllerId, XINPUT_STATE_EX& state)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   if (!m_getStateEx)
     return false;
@@ -172,7 +173,7 @@ bool CXInputDLL::GetStateWithGuide(unsigned int controllerId, XINPUT_STATE_EX& s
 
 bool CXInputDLL::SetState(unsigned int controllerId, XINPUT_VIBRATION& vibration)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   if (!m_setState)
     return false;
@@ -192,7 +193,7 @@ bool CXInputDLL::SetState(unsigned int controllerId, XINPUT_VIBRATION& vibration
 
 bool CXInputDLL::GetCapabilities(unsigned int controllerId, XINPUT_CAPABILITIES& caps)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   if (!m_getCaps)
     return false;
@@ -213,7 +214,7 @@ bool CXInputDLL::GetCapabilities(unsigned int controllerId, XINPUT_CAPABILITIES&
 
 bool CXInputDLL::GetBatteryInformation(unsigned int controllerId, BatteryDeviceType deviceType, XINPUT_BATTERY_INFORMATION& battery)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   if (!m_getBatteryInfo)
     return false;
@@ -249,7 +250,7 @@ bool CXInputDLL::GetBatteryInformation(unsigned int controllerId, BatteryDeviceT
 
 bool CXInputDLL::PowerOff(unsigned int controllerId)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   if (!m_powerOff)
     return false;

--- a/src/api/xinput/XInputDLL.h
+++ b/src/api/xinput/XInputDLL.h
@@ -21,8 +21,8 @@
 
 #include "utils/CommonIncludes.h"
 
-#include "p8-platform/threads/mutex.h"
 
+#include <mutex>
 #include <string>
 #include <windows.h>
 #include <Xinput.h>
@@ -113,6 +113,6 @@ namespace JOYSTICK
     FnXInputGetCapabilities m_getCaps;
     FnXInputGetBatteryInformation m_getBatteryInfo;
     FnXInputPowerOffController m_powerOff;
-    P8PLATFORM::CMutex m_mutex;
+    std::recursive_mutex m_mutex;
   };
 }

--- a/src/filesystem/DirectoryCache.cpp
+++ b/src/filesystem/DirectoryCache.cpp
@@ -19,8 +19,8 @@
  */
 
 #include "DirectoryCache.h"
+#include "utils/Timer.h"
 
-#include "p8-platform/util/timeutils.h"
 
 #include <algorithm>
 
@@ -66,7 +66,7 @@ bool CDirectoryCache::GetDirectory(const std::string& path, std::vector<kodi::vf
     const int64_t timestamp = record.first;
     const int64_t expires = timestamp + DIRECTORY_LIFETIME_MS;
 
-    if (expires <= P8PLATFORM::GetTimeMs())
+    if (expires <= GetTimeMs())
     {
       items = record.second;
       return true;
@@ -106,6 +106,6 @@ void CDirectoryCache::UpdateDirectory(const std::string& path, const std::vector
     }
   }
 
-  timestamp = P8PLATFORM::GetTimeMs();
+  timestamp = GetTimeMs();
   cachedItems = items;
 }

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -27,13 +27,12 @@
 #include "LogSyslog.h"
 #endif
 
-#include "p8-platform/threads/threads.h"
 
+#include <mutex>
 #include <stdarg.h>
 #include <stdio.h>
 
 using namespace JOYSTICK;
-using namespace P8PLATFORM;
 
 #define MAXSYSLOGBUF (256)
 
@@ -56,7 +55,7 @@ CLog::~CLog(void)
 
 bool CLog::SetType(SYS_LOG_TYPE type)
 {
-  P8PLATFORM::CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
   if (m_pipe && m_pipe->Type() == type)
     return true; // Already set
 
@@ -84,7 +83,7 @@ bool CLog::SetType(SYS_LOG_TYPE type)
 
 void CLog::SetPipe(ILog* pipe)
 {
-  P8PLATFORM::CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   const SYS_LOG_TYPE newType = pipe   ? pipe->Type()   : SYS_LOG_TYPE_NULL;
   const SYS_LOG_TYPE oldType = m_pipe ? m_pipe->Type() : SYS_LOG_TYPE_NULL;
@@ -95,7 +94,7 @@ void CLog::SetPipe(ILog* pipe)
 
 void CLog::SetLevel(SYS_LOG_LEVEL level)
 {
-  P8PLATFORM::CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   const SYS_LOG_LEVEL newLevel = level;
   const SYS_LOG_LEVEL oldLevel = m_level;
@@ -114,7 +113,7 @@ void CLog::Log(SYS_LOG_LEVEL level, const char* format, ...)
   vsnprintf(buf, MAXSYSLOGBUF - 1, fmt, ap);
   va_end(ap);
 
-  P8PLATFORM::CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   if (level > m_level)
     return;

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -22,7 +22,8 @@
 
 #include "ILog.h"
 
-#include "p8-platform/threads/mutex.h"
+
+#include <mutex>
 
 #ifndef esyslog
 #define esyslog(...) JOYSTICK::CLog::Get().Log(SYS_LOG_ERROR, __VA_ARGS__)
@@ -61,6 +62,6 @@ namespace JOYSTICK
   private:
     ILog*            m_pipe;
     SYS_LOG_LEVEL    m_level;
-    P8PLATFORM::CMutex m_mutex;
+    std::recursive_mutex m_mutex;
   };
 }

--- a/src/log/LogConsole.cpp
+++ b/src/log/LogConsole.cpp
@@ -21,16 +21,16 @@
 
 #include "LogConsole.h"
 
+#include <mutex>
 #include <stdio.h>
 
 using namespace JOYSTICK;
-using namespace P8PLATFORM;
 
 void CLogConsole::Log(SYS_LOG_LEVEL level, const char* logline)
 {
   // TODO: Prepend current date
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   printf("%s\n", logline);
 }

--- a/src/log/LogConsole.h
+++ b/src/log/LogConsole.h
@@ -22,7 +22,8 @@
 
 #include "ILog.h"
 
-#include "p8-platform/threads/mutex.h"
+
+#include <mutex>
 
 namespace JOYSTICK
 {
@@ -35,6 +36,6 @@ namespace JOYSTICK
     virtual SYS_LOG_TYPE Type(void) const override { return SYS_LOG_TYPE_CONSOLE; }
 
   private:
-    P8PLATFORM::CMutex m_mutex;
+    std::recursive_mutex m_mutex;
   };
 }

--- a/src/storage/ButtonMap.cpp
+++ b/src/storage/ButtonMap.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ButtonMap.h"
+#include "utils/Timer.h"
 #include "Device.h"
 #include "DeviceConfiguration.h"
 #include "StorageManager.h"
@@ -27,7 +28,6 @@
 #include "log/Log.h"
 
 #include <kodi/addon-instance/PeripheralUtils.h>
-#include "p8-platform/util/timeutils.h"
 
 #include <algorithm>
 
@@ -94,7 +94,7 @@ bool CButtonMap::SaveButtonMap()
 {
   if (Save())
   {
-    m_timestamp = P8PLATFORM::GetTimeMs();
+    m_timestamp = GetTimeMs();
     m_originalButtonMap.clear();
     m_bModified = false;
     return true;
@@ -130,7 +130,7 @@ bool CButtonMap::ResetButtonMap(const std::string& controllerId)
 bool CButtonMap::Refresh(void)
 {
   const int64_t expires = m_timestamp + RESOURCE_LIFETIME_MS;
-  const int64_t now = P8PLATFORM::GetTimeMs();
+  const int64_t now = GetTimeMs();
 
   if (now >= expires)
   {

--- a/src/storage/JustABunchOfFiles.cpp
+++ b/src/storage/JustABunchOfFiles.cpp
@@ -25,10 +25,10 @@
 #include "log/Log.h"
 #include "utils/StringUtils.h"
 
+#include <mutex>
 #include <algorithm>
 
 using namespace JOYSTICK;
-using namespace P8PLATFORM;
 
 #define FOLDER_DEPTH  1  // Recurse into max 1 subdirectories (provider)
 
@@ -188,7 +188,7 @@ const ButtonMap& CJustABunchOfFiles::GetButtonMap(const kodi::addon::Joystick& d
 {
   static ButtonMap empty;
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   // Update index
   IndexDirectory(m_strResourcePath, FOLDER_DEPTH);
@@ -208,7 +208,7 @@ bool CJustABunchOfFiles::MapFeatures(const kodi::addon::Joystick& driverInfo,
   if (!m_bReadWrite)
     return false;
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   CButtonMap* resource = m_resources.GetResource(driverInfo, true);
   if (resource)
@@ -222,7 +222,7 @@ bool CJustABunchOfFiles::MapFeatures(const kodi::addon::Joystick& driverInfo,
 
 bool CJustABunchOfFiles::GetIgnoredPrimitives(const kodi::addon::Joystick& driverInfo, PrimitiveVector& primitives)
 {
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   // Update index
   IndexDirectory(m_strResourcePath, FOLDER_DEPTH);
@@ -235,7 +235,7 @@ bool CJustABunchOfFiles::SetIgnoredPrimitives(const kodi::addon::Joystick& drive
   if (!m_bReadWrite)
     return false;
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   // Ensure resource exists
   m_resources.SetIgnoredPrimitives(driverInfo, primitives);
@@ -250,7 +250,7 @@ bool CJustABunchOfFiles::SaveButtonMap(const kodi::addon::Joystick& driverInfo)
 
   CDevice device(driverInfo);
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   CButtonMap* resource = m_resources.GetResource(device, false);
 
@@ -267,7 +267,7 @@ bool CJustABunchOfFiles::RevertButtonMap(const kodi::addon::Joystick& driverInfo
 
   CDevice device(driverInfo);
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   m_resources.Revert(device);
 
@@ -281,7 +281,7 @@ bool CJustABunchOfFiles::ResetButtonMap(const kodi::addon::Joystick& driverInfo,
 
   CDevice deviceInfo(driverInfo);
 
-  CLockObject lock(m_mutex);
+  std::lock_guard<std::recursive_mutex> lock(m_mutex);
 
   DevicePtr device = m_resources.GetDevice(deviceInfo);
   if (device)

--- a/src/storage/JustABunchOfFiles.h
+++ b/src/storage/JustABunchOfFiles.h
@@ -24,8 +24,8 @@
 #include "IDatabase.h"
 #include "filesystem/DirectoryCache.h"
 
-#include "p8-platform/threads/mutex.h"
 
+#include <mutex>
 #include <map>
 #include <memory>
 #include <string>
@@ -121,6 +121,6 @@ namespace JOYSTICK
     const bool        m_bReadWrite;
     CDirectoryCache   m_directoryCache;
     CResources        m_resources;
-    P8PLATFORM::CMutex  m_mutex;
+    std::recursive_mutex  m_mutex;
   };
 }

--- a/src/utils/Timer.h
+++ b/src/utils/Timer.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2015-2021 Team Kodi (https://kodi.tv)
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+namespace JOYSTICK
+{
+/*!
+ * \brief Milliseconds from a monotonic clock
+ *
+ * Only ever compared against other values from this function. steady_clock
+ * rather than the wall clock, so the intervals stay correct if the system time
+ * is adjusted.
+ */
+inline int64_t GetTimeMs()
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+} // namespace JOYSTICK


### PR DESCRIPTION
Per the discussion on #347. Kodi dropped p8-platform in xbmc/xbmc#28666, so requiring it now fails at configure time:

```
CMake Error at CMakeLists.txt:11 (find_package):
  By not providing "Findp8-platform.cmake" in CMAKE_MODULE_PATH ...
```

22 files referenced it, but only three things were genuinely used:

| p8-platform | uses | replacement |
|---|---|---|
| `CLockObject` | 54 | `std::lock_guard<std::recursive_mutex>` |
| `CMutex` | 11 | `std::recursive_mutex` |
| `GetTimeMs()` | 8 | `std::chrono::steady_clock`, behind `utils/Timer.h` |

The remaining `CThread` reference was inside a comment (`// TODO: Prepend CThread::ThreadId()`), so it was never a dependency.

## Two decisions worth reviewing

**Mutexes are recursive, not plain.** p8's `CMutex` allowed re-entry; `std::mutex` does not. A straight swap risks deadlocking anywhere the code re-enters a lock it already holds — intermittently, which is a worse failure than the one being fixed. This preserves today's semantics exactly. Tightening individual locks is worth doing but belongs in its own change, where each can be judged on its merits rather than 22 files at once. This also matches what `Piers` already does.

**Timing moves to a monotonic clock.** Every value `GetTimeMs()` feeds is an internal elapsed-time delta, so nothing depends on the epoch, and intervals no longer shift if the system clock is adjusted.

## Testing

I need to be straight about this: **I could not build this locally**, and not because of these changes.

`master` targets an older Kodi addon API than current Kodi master. After removing p8 the build gets further and then fails on unrelated pre-existing mismatches — `<kodi/addon-instance/PeripheralUtils.h>` has moved to `addon-instance/peripheral/` upstream, `kodi::CSettingValue` no longer exists, and several overrides no longer match. `Piers` already carries those updates; `master` does not.

So I verified this change by inspection and by confirming p8 is gone from the sources and the build system, and I'm relying on CI for the rest. If CI now surfaces those API mismatches, they are a separate piece of work and I'm happy to take it on — but I didn't want to bundle an API migration into a dependency removal, or to guess at which Kodi CI builds against.

Happy to be corrected if there's a build configuration I've missed.